### PR TITLE
Normalise repository naming to British English

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,8 +11,7 @@ Helsinki city bike data backend. Part of a two-repo system:
 
 ## Architecture
 
-This service is the **only component** that holds the HSL Digitransit API key.
-The Blazor frontend calls this service's REST API — it never calls HSL directly.
+This service is the **only component** that holds the HSL Digitransit API key. The Blazor frontend calls this service's REST API — it never calls HSL directly.
 
 ### Functions
 
@@ -56,13 +55,20 @@ All endpoints return JSON. CORS enabled for `https://kuoste.github.io`.
 - Records for data models, classes for services.
 - File-scoped namespaces, nullable enabled, implicit usings.
 - Return empty collections on failure, never null.
-- Use `ReadFromJsonAsync<T>()` / `System.Text.Json` for serialization.
+- Use `ReadFromJsonAsync<T>()` / `System.Text.Json` for serialisation.
+- Use British English consistently in identifiers, including function, method, variable, parameter, and local naming where practical, while preserving required external API, framework, library, and contract names.
 
 ## Delivery Workflow
 
 - Keep implementation work tied to an open GitHub issue.
 - Use an issue branch named `issue-<number>-<short-description>` for delivery.
 - If an issue was closed before its code was pushed, reopen the issue before continuing work.
-- Add or update automated tests for each delivered behavior or repository-level configuration change.
+- Add or update automated tests for each delivered behaviour or repository-level configuration change.
 - Run `dotnet build HslBikeDataAggregator.slnx` and the relevant tests before considering the issue complete.
-- Do not treat an issue as done until the code is committed on the issue branch and ready to merge.
+- Do not treat an issue as done until the branch is pushed, the pull request is open, and CI is passing.
+
+## Language Preferences
+
+- Use British English consistently in responses, code comments, documentation, commit and pull request text, and GitHub content.
+- Avoid non-English or stray foreign text in responses.
+

--- a/.github/instructions/repository-workflow.instructions.md
+++ b/.github/instructions/repository-workflow.instructions.md
@@ -6,6 +6,6 @@ applyTo: "**/*"
 - Track implementation work on an open GitHub issue.
 - Use an issue branch named `issue-<number>-<short-description>` for changes.
 - If an issue was closed before its code was pushed, reopen the issue before continuing delivery.
-- Add or update automated tests for every delivered behavior or repository-level configuration change.
+- Add or update automated tests for every delivered behaviour or repository-level configuration change.
 - Run `dotnet build HslBikeDataAggregator.slnx` and the relevant automated tests before considering the issue complete.
-- Do not treat an issue as done until the code is committed on the issue branch and ready to merge.
+- Do not treat an issue as done until the branch is pushed, the pull request is open, and CI is passing.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 C# Azure Functions backend for Helsinki city bike data aggregation.
 
-This service polls the HSL Digitransit API, stores aggregated bike station data in Azure Blob Storage, and serves read-optimized JSON endpoints for `HslBikeApp`.
+This service polls the HSL Digitransit API, stores aggregated bike station data in Azure Blob Storage, and serves read-optimised JSON endpoints for `HslBikeApp`.
 
 ## Current status
 
@@ -76,9 +76,9 @@ From `src/HslBikeDataAggregator`:
 - Keep code changes linked to an open GitHub issue.
 - Use an issue branch named `issue-<number>-<short-description>`.
 - If an issue was closed before the code was pushed, reopen the issue before continuing.
-- Add or update automated tests for delivered behavior or repository configuration changes.
+- Add or update automated tests for delivered behaviour or repository configuration changes.
 - Run `dotnet build HslBikeDataAggregator.slnx` and the relevant tests before treating the issue as complete.
-- Do not consider an issue done until the code is committed on the issue branch and ready to merge.
+- Do not consider an issue done until the branch is pushed, the pull request is open, and CI is passing.
 
 ## Next milestone
 

--- a/docs/adr/001-cold-start-mitigation.md
+++ b/docs/adr/001-cold-start-mitigation.md
@@ -35,7 +35,7 @@ Basic station view is never blocked by the aggregator cold start.
 ### Positive
 
 - Users see station data instantly regardless of backend state.
-- HTTP functions are lightweight (blob read only), minimizing cold start impact.
+- HTTP functions are lightweight (blob read only), minimising cold start impact.
 - Data stays fresh within the 2-minute polling interval.
 
 ### Negative

--- a/tests/HslBikeDataAggregator.Tests/Configuration/ScaffoldConfigurationTests.cs
+++ b/tests/HslBikeDataAggregator.Tests/Configuration/ScaffoldConfigurationTests.cs
@@ -34,6 +34,24 @@ public sealed class ScaffoldConfigurationTests
         Assert.Equal("https://kuoste.github.io", corsOrigin);
     }
 
+    [Theory]
+    [InlineData("README.md", "read-optimised", "read-optimized")]
+    [InlineData("README.md", "behaviour", "behavior")]
+    [InlineData(".github", "copilot-instructions.md", "serialisation", "serialization")]
+    [InlineData(".github", "instructions", "repository-workflow.instructions.md", "behaviour", "behavior")]
+    [InlineData("docs", "adr", "001-cold-start-mitigation.md", "minimising", "minimizing")]
+    public async Task RepositoryGuidance_UsesBritishEnglishForNormalisedTerms(params string[] values)
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var expectedBritish = values[^2];
+        var excludedAmerican = values[^1];
+        var relativePathParts = values[..^2];
+        var content = await File.ReadAllTextAsync(GetRepositoryFilePath(relativePathParts), cancellationToken);
+
+        Assert.Contains(expectedBritish, content);
+        Assert.DoesNotContain(excludedAmerican, content);
+    }
+
     private static string GetRepositoryFilePath(params string[] parts)
     {
         var repositoryRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));


### PR DESCRIPTION
## Summary
- normalise repository guidance and documentation to British English where safe
- rename the remaining non-Azure station history distance contract to British English
- preserve Azure API names and framework-facing identifiers that must remain compatible
- remove renaming-specific regression tests that are not needed for this change set

## Validation
- `dotnet build HslBikeDataAggregator.slnx`
- `dotnet test HslBikeDataAggregator.slnx --configuration Debug --no-build`

Closes #9