### PR TITLE
Implement PollStations timer flow

### DIFF
--- a/src/HslBikeDataAggregator/Configuration/PollStationsOptions.cs
+++ b/src/HslBikeDataAggregator/Configuration/PollStationsOptions.cs
@@ -1,0 +1,8 @@
+namespace HslBikeDataAggregator.Configuration;
+
+public sealed class PollStationsOptions
+{
+    public string DigitransitSubscriptionKey { get; set; } = string.Empty;
+
+    public int SnapshotHistoryLimit { get; set; } = 60;
+}

--- a/src/HslBikeDataAggregator/Functions/PollStationsFunction.cs
+++ b/src/HslBikeDataAggregator/Functions/PollStationsFunction.cs
@@ -1,14 +1,22 @@
+using HslBikeDataAggregator.Services;
+
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
 namespace HslBikeDataAggregator.Functions;
 
-public sealed class PollStationsFunction(ILogger<PollStationsFunction> logger)
+public sealed class PollStationsFunction(IPollStationsService pollStationsService, ILogger<PollStationsFunction> logger)
 {
     [Function(nameof(PollStations))]
-    public Task PollStations([TimerTrigger("%PollIntervalCron%")] TimerInfo timerInfo, CancellationToken cancellationToken)
+    public async Task PollStations([TimerTrigger("%PollIntervalCron%")] TimerInfo timerInfo, CancellationToken cancellationToken)
     {
         logger.LogInformation("PollStations trigger fired at {Timestamp}. Next schedule: {NextSchedule}.", DateTimeOffset.UtcNow, timerInfo.ScheduleStatus?.Next);
-        return Task.CompletedTask;
+        var result = await pollStationsService.PollAsync(cancellationToken);
+
+        logger.LogInformation(
+            "PollStations completed at {Timestamp}. Stored {StationCount} stations and retained {SnapshotCount} snapshots.",
+            result.Timestamp,
+            result.StationCount,
+            result.SnapshotCount);
     }
 }

--- a/src/HslBikeDataAggregator/Program.cs
+++ b/src/HslBikeDataAggregator/Program.cs
@@ -1,13 +1,41 @@
+using Azure.Storage.Blobs;
+
+using HslBikeDataAggregator.Configuration;
+using HslBikeDataAggregator.Services;
+using HslBikeDataAggregator.Storage;
+
 using Microsoft.Azure.Functions.Worker.Builder;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-
-using HslBikeDataAggregator.Services;
 
 var builder = FunctionsApplication.CreateBuilder(args);
 
 builder.ConfigureFunctionsWebApplication();
 
+builder.Services
+    .AddOptions<PollStationsOptions>()
+    .Configure<IConfiguration>((options, configuration) =>
+    {
+        options.DigitransitSubscriptionKey = configuration["DigitransitSubscriptionKey"] ?? string.Empty;
+        options.SnapshotHistoryLimit = configuration.GetValue<int?>("SnapshotHistoryLimit") ?? 60;
+    });
+
+builder.Services.AddHttpClient<DigitransitStationClient>();
+builder.Services.AddSingleton(TimeProvider.System);
+builder.Services.AddSingleton(provider =>
+{
+    var configuration = provider.GetRequiredService<IConfiguration>();
+    var connectionString = configuration["AzureWebJobsStorage"];
+    if (string.IsNullOrWhiteSpace(connectionString))
+    {
+        throw new InvalidOperationException("AzureWebJobsStorage setting is required.");
+    }
+
+    return new BlobContainerClient(connectionString, BikeDataBlobNames.ContainerName);
+});
+builder.Services.AddSingleton<IBikeDataBlobStorage, BikeDataBlobStorage>();
+builder.Services.AddSingleton<IPollStationsService, PollStationsService>();
 builder.Services.AddSingleton<AggregatedBikeDataService>();
 
 builder.Build().Run();

--- a/src/HslBikeDataAggregator/Services/DigitransitStationClient.cs
+++ b/src/HslBikeDataAggregator/Services/DigitransitStationClient.cs
@@ -1,0 +1,100 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+
+using HslBikeDataAggregator.Configuration;
+using HslBikeDataAggregator.Models;
+
+using Microsoft.Extensions.Options;
+
+namespace HslBikeDataAggregator.Services;
+
+public sealed class DigitransitStationClient(HttpClient httpClient, IOptions<PollStationsOptions> options)
+{
+    private const string GraphQlUrl = "https://api.digitransit.fi/routing/v2/hsl/gtfs/v1";
+
+    private const string Query = """
+        {
+          vehicleRentalStations {
+            stationId
+            name
+            lat
+            lon
+            allowPickup
+            allowDropoff
+            capacity
+            availableVehicles { byType { count } }
+            availableSpaces { byType { count } }
+          }
+        }
+        """;
+
+    public async Task<IReadOnlyList<BikeStation>> FetchStationsAsync(CancellationToken cancellationToken)
+    {
+        var subscriptionKey = options.Value.DigitransitSubscriptionKey;
+        if (string.IsNullOrWhiteSpace(subscriptionKey))
+        {
+            throw new InvalidOperationException("DigitransitSubscriptionKey setting is required.");
+        }
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, GraphQlUrl)
+        {
+            Content = JsonContent.Create(new GraphQlRequest(Query))
+        };
+
+        request.Headers.Add("digitransit-subscription-key", subscriptionKey);
+
+        using var response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        await using var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        using var document = await JsonDocument.ParseAsync(contentStream, cancellationToken: cancellationToken);
+
+        var stations = new List<BikeStation>();
+        var rentalStations = document.RootElement
+            .GetProperty("data")
+            .GetProperty("vehicleRentalStations");
+
+        foreach (var station in rentalStations.EnumerateArray())
+        {
+            stations.Add(new BikeStation
+            {
+                Id = station.GetProperty("stationId").GetString() ?? string.Empty,
+                Name = station.TryGetProperty("name", out var name) ? name.GetString() ?? string.Empty : string.Empty,
+                Lat = station.GetProperty("lat").GetDouble(),
+                Lon = station.GetProperty("lon").GetDouble(),
+                Capacity = station.TryGetProperty("capacity", out var capacity) ? capacity.GetInt32() : 0,
+                BikesAvailable = SumByType(station, "availableVehicles"),
+                SpacesAvailable = SumByType(station, "availableSpaces"),
+                IsActive = station.TryGetProperty("allowPickup", out var allowPickup) && allowPickup.GetBoolean()
+            });
+        }
+
+        return stations;
+    }
+
+    private static int SumByType(JsonElement station, string propertyName)
+    {
+        if (!station.TryGetProperty(propertyName, out var property))
+        {
+            return 0;
+        }
+
+        if (!property.TryGetProperty("byType", out var byType))
+        {
+            return 0;
+        }
+
+        var total = 0;
+        foreach (var entry in byType.EnumerateArray())
+        {
+            if (entry.TryGetProperty("count", out var count))
+            {
+                total += count.GetInt32();
+            }
+        }
+
+        return total;
+    }
+
+    private sealed record GraphQlRequest(string Query);
+}

--- a/src/HslBikeDataAggregator/Services/IPollStationsService.cs
+++ b/src/HslBikeDataAggregator/Services/IPollStationsService.cs
@@ -1,0 +1,6 @@
+namespace HslBikeDataAggregator.Services;
+
+public interface IPollStationsService
+{
+    Task<PollStationsResult> PollAsync(CancellationToken cancellationToken);
+}

--- a/src/HslBikeDataAggregator/Services/PollStationsResult.cs
+++ b/src/HslBikeDataAggregator/Services/PollStationsResult.cs
@@ -1,0 +1,3 @@
+namespace HslBikeDataAggregator.Services;
+
+public sealed record PollStationsResult(DateTimeOffset Timestamp, int StationCount, int SnapshotCount);

--- a/src/HslBikeDataAggregator/Services/PollStationsService.cs
+++ b/src/HslBikeDataAggregator/Services/PollStationsService.cs
@@ -1,0 +1,46 @@
+using HslBikeDataAggregator.Configuration;
+using HslBikeDataAggregator.Models;
+using HslBikeDataAggregator.Storage;
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace HslBikeDataAggregator.Services;
+
+public sealed class PollStationsService(
+    DigitransitStationClient digitransitStationClient,
+    IBikeDataBlobStorage bikeDataBlobStorage,
+    IOptions<PollStationsOptions> options,
+    TimeProvider timeProvider,
+    ILogger<PollStationsService> logger) : IPollStationsService
+{
+    public async Task<PollStationsResult> PollAsync(CancellationToken cancellationToken)
+    {
+        var stations = await digitransitStationClient.FetchStationsAsync(cancellationToken);
+        var timestamp = timeProvider.GetUtcNow();
+        var snapshotHistoryLimit = Math.Max(1, options.Value.SnapshotHistoryLimit);
+        var existingSnapshots = await bikeDataBlobStorage.GetRecentSnapshotsAsync(cancellationToken);
+        var currentSnapshot = new StationSnapshot
+        {
+            Timestamp = timestamp,
+            BikeCounts = stations.ToDictionary(station => station.Id, station => station.BikesAvailable, StringComparer.Ordinal)
+        };
+
+        var updatedSnapshots = existingSnapshots
+            .Append(currentSnapshot)
+            .OrderBy(snapshot => snapshot.Timestamp)
+            .TakeLast(snapshotHistoryLimit)
+            .ToArray();
+
+        await bikeDataBlobStorage.WriteLatestStationsAsync(stations, cancellationToken);
+        await bikeDataBlobStorage.WriteRecentSnapshotsAsync(updatedSnapshots, cancellationToken);
+
+        logger.LogInformation(
+            "Stored {StationCount} stations and {SnapshotCount} snapshots at {Timestamp}.",
+            stations.Count,
+            updatedSnapshots.Length,
+            timestamp);
+
+        return new PollStationsResult(timestamp, stations.Count, updatedSnapshots.Length);
+    }
+}

--- a/src/HslBikeDataAggregator/Storage/BikeDataBlobNames.cs
+++ b/src/HslBikeDataAggregator/Storage/BikeDataBlobNames.cs
@@ -2,6 +2,7 @@ namespace HslBikeDataAggregator.Storage;
 
 public static class BikeDataBlobNames
 {
+    public const string ContainerName = "bike-data";
     public const string LatestStations = "stations/latest.json";
     public const string RecentSnapshots = "snapshots/recent.json";
 

--- a/src/HslBikeDataAggregator/Storage/BikeDataBlobStorage.cs
+++ b/src/HslBikeDataAggregator/Storage/BikeDataBlobStorage.cs
@@ -1,0 +1,51 @@
+using System.Text.Json;
+
+using Azure;
+using Azure.Storage.Blobs;
+
+using HslBikeDataAggregator.Models;
+
+namespace HslBikeDataAggregator.Storage;
+
+public sealed class BikeDataBlobStorage(BlobContainerClient blobContainerClient) : IBikeDataBlobStorage
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web);
+
+    public async Task<IReadOnlyList<StationSnapshot>> GetRecentSnapshotsAsync(CancellationToken cancellationToken)
+    {
+        await blobContainerClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
+
+        try
+        {
+            var response = await blobContainerClient
+                .GetBlobClient(BikeDataBlobNames.RecentSnapshots)
+                .DownloadContentAsync(cancellationToken);
+
+            return response.Value.Content.ToObjectFromJson<List<StationSnapshot>>(SerializerOptions) ?? [];
+        }
+        catch (RequestFailedException exception) when (exception.Status == 404)
+        {
+            return [];
+        }
+    }
+
+    public async Task WriteLatestStationsAsync(IReadOnlyList<BikeStation> stations, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(stations);
+
+        await blobContainerClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
+        await blobContainerClient
+            .GetBlobClient(BikeDataBlobNames.LatestStations)
+            .UploadAsync(BinaryData.FromObjectAsJson(stations, SerializerOptions), overwrite: true, cancellationToken);
+    }
+
+    public async Task WriteRecentSnapshotsAsync(IReadOnlyList<StationSnapshot> snapshots, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(snapshots);
+
+        await blobContainerClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
+        await blobContainerClient
+            .GetBlobClient(BikeDataBlobNames.RecentSnapshots)
+            .UploadAsync(BinaryData.FromObjectAsJson(snapshots, SerializerOptions), overwrite: true, cancellationToken);
+    }
+}

--- a/src/HslBikeDataAggregator/Storage/IBikeDataBlobStorage.cs
+++ b/src/HslBikeDataAggregator/Storage/IBikeDataBlobStorage.cs
@@ -1,0 +1,12 @@
+using HslBikeDataAggregator.Models;
+
+namespace HslBikeDataAggregator.Storage;
+
+public interface IBikeDataBlobStorage
+{
+    Task<IReadOnlyList<StationSnapshot>> GetRecentSnapshotsAsync(CancellationToken cancellationToken);
+
+    Task WriteLatestStationsAsync(IReadOnlyList<BikeStation> stations, CancellationToken cancellationToken);
+
+    Task WriteRecentSnapshotsAsync(IReadOnlyList<StationSnapshot> snapshots, CancellationToken cancellationToken);
+}

--- a/tests/HslBikeDataAggregator.Tests/Functions/PollStationsFunctionTests.cs
+++ b/tests/HslBikeDataAggregator.Tests/Functions/PollStationsFunctionTests.cs
@@ -1,0 +1,24 @@
+using System.Reflection;
+
+using HslBikeDataAggregator.Functions;
+
+using Microsoft.Azure.Functions.Worker;
+
+namespace HslBikeDataAggregator.Tests.Functions;
+
+public sealed class PollStationsFunctionTests
+{
+    [Fact]
+    public void PollStations_UsesConfiguredCronExpression()
+    {
+        var method = typeof(PollStationsFunction).GetMethod(nameof(PollStationsFunction.PollStations), BindingFlags.Instance | BindingFlags.Public);
+
+        Assert.NotNull(method);
+
+        var timerParameter = method!.GetParameters()[0];
+        var timerTriggerAttribute = timerParameter.GetCustomAttribute<TimerTriggerAttribute>();
+
+        Assert.NotNull(timerTriggerAttribute);
+        Assert.Equal("%PollIntervalCron%", timerTriggerAttribute!.Schedule);
+    }
+}

--- a/tests/HslBikeDataAggregator.Tests/Services/PollStationsServiceTests.cs
+++ b/tests/HslBikeDataAggregator.Tests/Services/PollStationsServiceTests.cs
@@ -1,0 +1,142 @@
+using System.Net;
+using System.Text;
+
+using HslBikeDataAggregator.Configuration;
+using HslBikeDataAggregator.Models;
+using HslBikeDataAggregator.Services;
+using HslBikeDataAggregator.Storage;
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+using Moq;
+
+namespace HslBikeDataAggregator.Tests.Services;
+
+public sealed class PollStationsServiceTests
+{
+    [Fact]
+    public async Task PollAsync_StoresLatestStationsAndTrimsSnapshotHistory()
+    {
+        var capturedRequestBody = string.Empty;
+        HttpRequestMessage? capturedRequest = null;
+        var handler = new StubHttpMessageHandler(async request =>
+        {
+            capturedRequest = request;
+            capturedRequestBody = await request.Content!.ReadAsStringAsync(TestContext.Current.CancellationToken);
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """
+                    {
+                      "data": {
+                        "vehicleRentalStations": [
+                          {
+                            "stationId": "001",
+                            "name": "Central Station",
+                            "lat": 60.1708,
+                            "lon": 24.941,
+                            "allowPickup": true,
+                            "allowDropoff": true,
+                            "capacity": 24,
+                            "availableVehicles": {
+                              "byType": [
+                                { "count": 7 },
+                                { "count": 2 }
+                              ]
+                            },
+                            "availableSpaces": {
+                              "byType": [
+                                { "count": 5 }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                    """,
+                    Encoding.UTF8,
+                    "application/json")
+            };
+        });
+
+        var options = Options.Create(new PollStationsOptions
+        {
+            DigitransitSubscriptionKey = "test-subscription-key",
+            SnapshotHistoryLimit = 2
+        });
+        var digitransitStationClient = new DigitransitStationClient(new HttpClient(handler), options);
+        var blobStorage = new Mock<IBikeDataBlobStorage>();
+        blobStorage
+            .Setup(storage => storage.GetRecentSnapshotsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new StationSnapshot
+                {
+                    Timestamp = new DateTimeOffset(2026, 4, 3, 10, 0, 0, TimeSpan.Zero),
+                    BikeCounts = new Dictionary<string, int> { ["old"] = 3 }
+                },
+                new StationSnapshot
+                {
+                    Timestamp = new DateTimeOffset(2026, 4, 3, 10, 5, 0, TimeSpan.Zero),
+                    BikeCounts = new Dictionary<string, int> { ["older"] = 4 }
+                }
+            ]);
+
+        IReadOnlyList<BikeStation>? latestStations = null;
+        blobStorage
+            .Setup(storage => storage.WriteLatestStationsAsync(It.IsAny<IReadOnlyList<BikeStation>>(), It.IsAny<CancellationToken>()))
+            .Callback<IReadOnlyList<BikeStation>, CancellationToken>((stations, _) => latestStations = stations)
+            .Returns(Task.CompletedTask);
+
+        IReadOnlyList<StationSnapshot>? writtenSnapshots = null;
+        blobStorage
+            .Setup(storage => storage.WriteRecentSnapshotsAsync(It.IsAny<IReadOnlyList<StationSnapshot>>(), It.IsAny<CancellationToken>()))
+            .Callback<IReadOnlyList<StationSnapshot>, CancellationToken>((snapshots, _) => writtenSnapshots = snapshots)
+            .Returns(Task.CompletedTask);
+
+        var timestamp = new DateTimeOffset(2026, 4, 3, 10, 10, 0, TimeSpan.Zero);
+        var service = new PollStationsService(
+            digitransitStationClient,
+            blobStorage.Object,
+            options,
+            new FixedTimeProvider(timestamp),
+            NullLogger<PollStationsService>.Instance);
+
+        var result = await service.PollAsync(TestContext.Current.CancellationToken);
+
+        Assert.NotNull(capturedRequest);
+        Assert.Equal(HttpMethod.Post, capturedRequest.Method);
+        Assert.True(capturedRequest.Headers.TryGetValues("digitransit-subscription-key", out var headerValues));
+        Assert.Contains("test-subscription-key", headerValues);
+        Assert.Contains("vehicleRentalStations", capturedRequestBody);
+
+        var station = Assert.Single(latestStations!);
+        Assert.Equal("001", station.Id);
+        Assert.Equal("Central Station", station.Name);
+        Assert.Equal(9, station.BikesAvailable);
+        Assert.Equal(5, station.SpacesAvailable);
+        Assert.True(station.IsActive);
+
+        Assert.NotNull(writtenSnapshots);
+        Assert.Equal(2, writtenSnapshots!.Count);
+        Assert.Equal(new DateTimeOffset(2026, 4, 3, 10, 5, 0, TimeSpan.Zero), writtenSnapshots[0].Timestamp);
+        Assert.Equal(timestamp, writtenSnapshots[1].Timestamp);
+        Assert.Equal(9, writtenSnapshots[1].BikeCounts["001"]);
+
+        Assert.Equal(timestamp, result.Timestamp);
+        Assert.Equal(1, result.StationCount);
+        Assert.Equal(2, result.SnapshotCount);
+    }
+
+    private sealed class StubHttpMessageHandler(Func<HttpRequestMessage, Task<HttpResponseMessage>> handler) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => handler(request);
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset timestamp) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => timestamp;
+    }
+}


### PR DESCRIPTION
## Summary
- implement the `PollStations` timer flow against the HSL Digitransit GraphQL API
- persist latest station data and rolling snapshot history to Azure Blob Storage
- add tests for the timer configuration and polling persistence behaviour

## Validation
- `dotnet build HslBikeDataAggregator.slnx`
- `HslBikeDataAggregator.Tests`