### PR TITLE
Implement GetStations blob read path

### DIFF
--- a/src/HslBikeDataAggregator/Services/AggregatedBikeDataService.cs
+++ b/src/HslBikeDataAggregator/Services/AggregatedBikeDataService.cs
@@ -1,11 +1,13 @@
+using HslBikeDataAggregator.Storage;
+
 using HslBikeDataAggregator.Models;
 
 namespace HslBikeDataAggregator.Services;
 
-public sealed class AggregatedBikeDataService
+public sealed class AggregatedBikeDataService(IBikeDataBlobStorage bikeDataBlobStorage)
 {
     public Task<IReadOnlyList<BikeStation>> GetStationsAsync(CancellationToken cancellationToken)
-        => Task.FromResult<IReadOnlyList<BikeStation>>([]);
+        => bikeDataBlobStorage.GetLatestStationsAsync(cancellationToken);
 
     public Task<IReadOnlyList<StationSnapshot>> GetSnapshotsAsync(CancellationToken cancellationToken)
         => Task.FromResult<IReadOnlyList<StationSnapshot>>([]);

--- a/src/HslBikeDataAggregator/Storage/BikeDataBlobStorage.cs
+++ b/src/HslBikeDataAggregator/Storage/BikeDataBlobStorage.cs
@@ -11,17 +11,23 @@ public sealed class BikeDataBlobStorage(BlobContainerClient blobContainerClient)
 {
     private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web);
 
+    public Task<IReadOnlyList<BikeStation>> GetLatestStationsAsync(CancellationToken cancellationToken)
+        => ReadBlobAsync<BikeStation>(BikeDataBlobNames.LatestStations, cancellationToken);
+
     public async Task<IReadOnlyList<StationSnapshot>> GetRecentSnapshotsAsync(CancellationToken cancellationToken)
+        => await ReadBlobAsync<StationSnapshot>(BikeDataBlobNames.RecentSnapshots, cancellationToken);
+
+    private async Task<IReadOnlyList<T>> ReadBlobAsync<T>(string blobName, CancellationToken cancellationToken)
     {
         await blobContainerClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
 
         try
         {
             var response = await blobContainerClient
-                .GetBlobClient(BikeDataBlobNames.RecentSnapshots)
+                .GetBlobClient(blobName)
                 .DownloadContentAsync(cancellationToken);
 
-            return response.Value.Content.ToObjectFromJson<List<StationSnapshot>>(SerializerOptions) ?? [];
+            return response.Value.Content.ToObjectFromJson<List<T>>(SerializerOptions) ?? [];
         }
         catch (RequestFailedException exception) when (exception.Status == 404)
         {

--- a/src/HslBikeDataAggregator/Storage/IBikeDataBlobStorage.cs
+++ b/src/HslBikeDataAggregator/Storage/IBikeDataBlobStorage.cs
@@ -4,6 +4,8 @@ namespace HslBikeDataAggregator.Storage;
 
 public interface IBikeDataBlobStorage
 {
+    Task<IReadOnlyList<BikeStation>> GetLatestStationsAsync(CancellationToken cancellationToken);
+
     Task<IReadOnlyList<StationSnapshot>> GetRecentSnapshotsAsync(CancellationToken cancellationToken);
 
     Task WriteLatestStationsAsync(IReadOnlyList<BikeStation> stations, CancellationToken cancellationToken);

--- a/tests/HslBikeDataAggregator.Tests/Functions/StationsFunctionsTests.cs
+++ b/tests/HslBikeDataAggregator.Tests/Functions/StationsFunctionsTests.cs
@@ -4,7 +4,9 @@ using System.Security.Claims;
 using Azure.Core.Serialization;
 
 using HslBikeDataAggregator.Functions;
+using HslBikeDataAggregator.Models;
 using HslBikeDataAggregator.Services;
+using HslBikeDataAggregator.Storage;
 
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -47,7 +49,24 @@ public sealed class StationsFunctionsTests
         request.SetupGet(httpRequest => httpRequest.Method).Returns("GET");
         request.SetupGet(httpRequest => httpRequest.Url).Returns(new Uri("https://localhost/api/stations"));
 
-        var function = new StationsFunctions(new AggregatedBikeDataService(), NullLogger<StationsFunctions>.Instance);
+        var blobStorage = new Mock<IBikeDataBlobStorage>();
+        blobStorage
+            .Setup(storage => storage.GetLatestStationsAsync(cancellationToken))
+            .ReturnsAsync([
+                new BikeStation
+                {
+                    Id = "station-001",
+                    Name = "Central Station",
+                    Lat = 60.1708,
+                    Lon = 24.941,
+                    Capacity = 24,
+                    BikesAvailable = 8,
+                    SpacesAvailable = 16,
+                    IsActive = true
+                }
+            ]);
+
+        var function = new StationsFunctions(new AggregatedBikeDataService(blobStorage.Object), NullLogger<StationsFunctions>.Instance);
 
         var responseData = await function.GetStations(request.Object, cancellationToken);
 
@@ -57,6 +76,6 @@ public sealed class StationsFunctionsTests
 
         responseData.Body.Position = 0;
         using var reader = new StreamReader(responseData.Body);
-        Assert.Equal("[]", await reader.ReadToEndAsync(cancellationToken));
+        Assert.Equal("[{\"id\":\"station-001\",\"name\":\"Central Station\",\"lat\":60.1708,\"lon\":24.941,\"capacity\":24,\"bikesAvailable\":8,\"spacesAvailable\":16,\"isActive\":true}]", await reader.ReadToEndAsync(cancellationToken));
     }
 }

--- a/tests/HslBikeDataAggregator.Tests/Services/AggregatedBikeDataServiceTests.cs
+++ b/tests/HslBikeDataAggregator.Tests/Services/AggregatedBikeDataServiceTests.cs
@@ -1,4 +1,8 @@
+using HslBikeDataAggregator.Models;
 using HslBikeDataAggregator.Services;
+using HslBikeDataAggregator.Storage;
+
+using Moq;
 
 namespace HslBikeDataAggregator.Tests.Services;
 
@@ -7,9 +11,42 @@ public sealed class AggregatedBikeDataServiceTests
     private static readonly CancellationToken CancellationToken = CancellationToken.None;
 
     [Fact]
-    public async Task GetStationsAsync_ReturnsEmptyCollection()
+    public async Task GetStationsAsync_ReturnsStationsFromBlobStorage()
     {
-        var service = new AggregatedBikeDataService();
+        var blobStorage = new Mock<IBikeDataBlobStorage>();
+        blobStorage
+            .Setup(storage => storage.GetLatestStationsAsync(CancellationToken))
+            .ReturnsAsync([
+                new BikeStation
+                {
+                    Id = "station-001",
+                    Name = "Central Station",
+                    Lat = 60.1708,
+                    Lon = 24.941,
+                    Capacity = 24,
+                    BikesAvailable = 8,
+                    SpacesAvailable = 16,
+                    IsActive = true
+                }
+            ]);
+
+        var service = new AggregatedBikeDataService(blobStorage.Object);
+
+        var result = await service.GetStationsAsync(CancellationToken);
+
+        var station = Assert.Single(result);
+        Assert.Equal("station-001", station.Id);
+    }
+
+    [Fact]
+    public async Task GetStationsAsync_ReturnsEmptyCollectionWhenBlobStorageHasNoStations()
+    {
+        var blobStorage = new Mock<IBikeDataBlobStorage>();
+        blobStorage
+            .Setup(storage => storage.GetLatestStationsAsync(CancellationToken))
+            .ReturnsAsync([]);
+
+        var service = new AggregatedBikeDataService(blobStorage.Object);
 
         var result = await service.GetStationsAsync(CancellationToken);
 
@@ -19,7 +56,7 @@ public sealed class AggregatedBikeDataServiceTests
     [Fact]
     public async Task GetSnapshotsAsync_ReturnsEmptyCollection()
     {
-        var service = new AggregatedBikeDataService();
+        var service = new AggregatedBikeDataService(Mock.Of<IBikeDataBlobStorage>());
 
         var result = await service.GetSnapshotsAsync(CancellationToken);
 
@@ -29,7 +66,7 @@ public sealed class AggregatedBikeDataServiceTests
     [Fact]
     public async Task GetAvailabilityAsync_ReturnsEmptyCollection()
     {
-        var service = new AggregatedBikeDataService();
+        var service = new AggregatedBikeDataService(Mock.Of<IBikeDataBlobStorage>());
 
         var result = await service.GetAvailabilityAsync("station-001", CancellationToken);
 
@@ -39,7 +76,7 @@ public sealed class AggregatedBikeDataServiceTests
     [Fact]
     public async Task GetDestinationsAsync_ReturnsEmptyCollection()
     {
-        var service = new AggregatedBikeDataService();
+        var service = new AggregatedBikeDataService(Mock.Of<IBikeDataBlobStorage>());
 
         var result = await service.GetDestinationsAsync("station-001", CancellationToken);
 


### PR DESCRIPTION
## Summary
- add latest-stations blob reads to the storage layer
- wire `AggregatedBikeDataService.GetStationsAsync` to blob storage
- update function and service tests for the storage-backed `GET /api/stations` path

## Validation
- `dotnet build HslBikeDataAggregator.slnx`
- targeted `StationsFunctionsTests` and `AggregatedBikeDataServiceTests`
- `HslBikeDataAggregator.Tests`