### PR TITLE
Fix Azure deployment parameter file usage

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -67,7 +67,7 @@ jobs:
             az deployment group create \
               --resource-group "$AZURE_RESOURCE_GROUP" \
               --template-file infra/main.bicep \
-              --parameters @infra/dev.bicepparam \
+              --parameters @infra/dev.json \
               functionAppName="$AZURE_FUNCTION_APP_NAME" \
               location="$AZURE_LOCATION"
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -72,7 +72,7 @@ jobs:
             az deployment group create \
               --resource-group "$AZURE_RESOURCE_GROUP" \
               --template-file infra/main.bicep \
-              --parameters @infra/prod.bicepparam \
+              --parameters @infra/prod.json \
               functionAppName="$AZURE_FUNCTION_APP_NAME" \
               location="$AZURE_LOCATION"
 

--- a/tests/HslBikeDataAggregator.Tests/Configuration/DeploymentWorkflowConfigurationTests.cs
+++ b/tests/HslBikeDataAggregator.Tests/Configuration/DeploymentWorkflowConfigurationTests.cs
@@ -32,6 +32,7 @@ public sealed class DeploymentWorkflowConfigurationTests
         var yaml = await File.ReadAllTextAsync(GetRepositoryFilePath(".github", "workflows", "deploy-dev.yml"), cancellationToken);
 
         Assert.Contains("environment: dev", yaml, StringComparison.Ordinal);
+        Assert.Contains("@infra/dev.json", yaml, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -41,6 +42,7 @@ public sealed class DeploymentWorkflowConfigurationTests
         var yaml = await File.ReadAllTextAsync(GetRepositoryFilePath(".github", "workflows", "deploy-prod.yml"), cancellationToken);
 
         Assert.Contains("environment: prod", yaml, StringComparison.Ordinal);
+        Assert.Contains("@infra/prod.json", yaml, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- update the Azure deployment workflows to use the compiled JSON parameter files
- keep the Bicep parameter files for source control and CI validation
- update the deployment workflow tests to cover the workflow parameter file references

## Validation
- `dotnet build HslBikeDataAggregator.slnx`
- `HslBikeDataAggregator.Tests.Configuration.DeploymentWorkflowConfigurationTests`