### PR TITLE
Implement GetSnapshots blob read path

### DIFF
--- a/src/HslBikeDataAggregator/Services/AggregatedBikeDataService.cs
+++ b/src/HslBikeDataAggregator/Services/AggregatedBikeDataService.cs
@@ -10,7 +10,7 @@ public sealed class AggregatedBikeDataService(IBikeDataBlobStorage bikeDataBlobS
         => bikeDataBlobStorage.GetLatestStationsAsync(cancellationToken);
 
     public Task<IReadOnlyList<StationSnapshot>> GetSnapshotsAsync(CancellationToken cancellationToken)
-        => Task.FromResult<IReadOnlyList<StationSnapshot>>([]);
+        => bikeDataBlobStorage.GetRecentSnapshotsAsync(cancellationToken);
 
     public Task<IReadOnlyList<HourlyAvailability>> GetAvailabilityAsync(string stationId, CancellationToken cancellationToken)
         => Task.FromResult<IReadOnlyList<HourlyAvailability>>([]);

--- a/tests/HslBikeDataAggregator.Tests/Functions/StationsFunctionsTests.cs
+++ b/tests/HslBikeDataAggregator.Tests/Functions/StationsFunctionsTests.cs
@@ -78,4 +78,62 @@ public sealed class StationsFunctionsTests
         using var reader = new StreamReader(responseData.Body);
         Assert.Equal("[{\"id\":\"station-001\",\"name\":\"Central Station\",\"lat\":60.1708,\"lon\":24.941,\"capacity\":24,\"bikesAvailable\":8,\"spacesAvailable\":16,\"isActive\":true}]", await reader.ReadToEndAsync(cancellationToken));
     }
+
+    [Fact]
+    public async Task GetSnapshots_ReturnsOkResponseWithStoredSnapshots()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var services = new ServiceCollection();
+        services
+            .AddOptions<WorkerOptions>()
+            .Configure(options => options.Serializer = new JsonObjectSerializer());
+
+        var serviceProvider = services.BuildServiceProvider();
+
+        var functionContext = new Mock<FunctionContext>();
+        functionContext.SetupProperty(context => context.InstanceServices, serviceProvider);
+
+        var responseHeaders = new HttpHeadersCollection();
+        var responseBody = new MemoryStream();
+        var response = new Mock<HttpResponseData>(functionContext.Object);
+        response.SetupProperty(httpResponse => httpResponse.StatusCode);
+        response.SetupProperty(httpResponse => httpResponse.Body, responseBody);
+        response.SetupGet(httpResponse => httpResponse.Headers).Returns(responseHeaders);
+        response.SetupGet(httpResponse => httpResponse.Cookies).Returns(Mock.Of<HttpCookies>());
+
+        var request = new Mock<HttpRequestData>(functionContext.Object);
+        request.Setup(httpRequest => httpRequest.CreateResponse()).Returns(response.Object);
+        request.SetupGet(httpRequest => httpRequest.Body).Returns(Stream.Null);
+        request.SetupGet(httpRequest => httpRequest.Headers).Returns(new HttpHeadersCollection());
+        request.SetupGet(httpRequest => httpRequest.Identities).Returns(Array.Empty<ClaimsIdentity>());
+        request.SetupGet(httpRequest => httpRequest.Method).Returns("GET");
+        request.SetupGet(httpRequest => httpRequest.Url).Returns(new Uri("https://localhost/api/snapshots"));
+
+        var blobStorage = new Mock<IBikeDataBlobStorage>();
+        blobStorage
+            .Setup(storage => storage.GetRecentSnapshotsAsync(cancellationToken))
+            .ReturnsAsync([
+                new StationSnapshot
+                {
+                    Timestamp = new DateTimeOffset(2026, 4, 4, 9, 45, 0, TimeSpan.Zero),
+                    BikeCounts = new Dictionary<string, int>
+                    {
+                        ["station-001"] = 8,
+                        ["station-002"] = 3
+                    }
+                }
+            ]);
+
+        var function = new StationsFunctions(new AggregatedBikeDataService(blobStorage.Object), NullLogger<StationsFunctions>.Instance);
+
+        var responseData = await function.GetSnapshots(request.Object, cancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, responseData.StatusCode);
+        Assert.True(responseData.Headers.TryGetValues("Access-Control-Allow-Origin", out var origins));
+        Assert.Contains("https://kuoste.github.io", origins);
+
+        responseData.Body.Position = 0;
+        using var reader = new StreamReader(responseData.Body);
+        Assert.Equal("[{\"timestamp\":\"2026-04-04T09:45:00+00:00\",\"bikeCounts\":{\"station-001\":8,\"station-002\":3}}]", await reader.ReadToEndAsync(cancellationToken));
+    }
 }

--- a/tests/HslBikeDataAggregator.Tests/Services/AggregatedBikeDataServiceTests.cs
+++ b/tests/HslBikeDataAggregator.Tests/Services/AggregatedBikeDataServiceTests.cs
@@ -54,9 +54,39 @@ public sealed class AggregatedBikeDataServiceTests
     }
 
     [Fact]
-    public async Task GetSnapshotsAsync_ReturnsEmptyCollection()
+    public async Task GetSnapshotsAsync_ReturnsSnapshotsFromBlobStorage()
     {
-        var service = new AggregatedBikeDataService(Mock.Of<IBikeDataBlobStorage>());
+        var blobStorage = new Mock<IBikeDataBlobStorage>();
+        blobStorage
+            .Setup(storage => storage.GetRecentSnapshotsAsync(CancellationToken))
+            .ReturnsAsync([
+                new StationSnapshot
+                {
+                    Timestamp = new DateTimeOffset(2026, 4, 4, 9, 45, 0, TimeSpan.Zero),
+                    BikeCounts = new Dictionary<string, int>
+                    {
+                        ["station-001"] = 8
+                    }
+                }
+            ]);
+
+        var service = new AggregatedBikeDataService(blobStorage.Object);
+
+        var result = await service.GetSnapshotsAsync(CancellationToken);
+
+        var snapshot = Assert.Single(result);
+        Assert.Equal(8, snapshot.BikeCounts["station-001"]);
+    }
+
+    [Fact]
+    public async Task GetSnapshotsAsync_ReturnsEmptyCollectionWhenBlobStorageHasNoSnapshots()
+    {
+        var blobStorage = new Mock<IBikeDataBlobStorage>();
+        blobStorage
+            .Setup(storage => storage.GetRecentSnapshotsAsync(CancellationToken))
+            .ReturnsAsync([]);
+
+        var service = new AggregatedBikeDataService(blobStorage.Object);
 
         var result = await service.GetSnapshotsAsync(CancellationToken);
 


### PR DESCRIPTION
## Summary
- wire `AggregatedBikeDataService.GetSnapshotsAsync` to blob storage
- add HTTP test coverage for `GET /api/snapshots`
- add service test coverage for stored and empty snapshot reads

## Validation
- `dotnet build HslBikeDataAggregator.slnx`
- targeted `StationsFunctionsTests` and `AggregatedBikeDataServiceTests`
- `HslBikeDataAggregator.Tests`

Closes #2 
Closes #3 
Closes #4 