### PR TITLE
Process HSL open history destinations

### DIFF
--- a/src/HslBikeDataAggregator/Configuration/HistoryProcessingOptions.cs
+++ b/src/HslBikeDataAggregator/Configuration/HistoryProcessingOptions.cs
@@ -1,0 +1,6 @@
+namespace HslBikeDataAggregator.Configuration;
+
+public sealed class HistoryProcessingOptions
+{
+    public string[] TripHistoryUrls { get; set; } = [];
+}

--- a/src/HslBikeDataAggregator/Functions/ProcessStationHistoryFunction.cs
+++ b/src/HslBikeDataAggregator/Functions/ProcessStationHistoryFunction.cs
@@ -1,0 +1,31 @@
+using HslBikeDataAggregator.Services;
+
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace HslBikeDataAggregator.Functions;
+
+public sealed class ProcessStationHistoryFunction(
+    ProcessStationHistoryService processStationHistoryService,
+    ILogger<ProcessStationHistoryFunction> logger)
+{
+    /// <summary>
+    /// Aggregates configured HSL trip history CSV files into per-station destination profiles.
+    /// </summary>
+    [Function(nameof(ProcessStationHistory))]
+    public async Task ProcessStationHistory([TimerTrigger("%HistoryProcessingCron%")] TimerInfo timerInfo, CancellationToken cancellationToken)
+    {
+        logger.LogInformation(
+            "ProcessStationHistory trigger fired at {Timestamp}. Next schedule: {NextSchedule}.",
+            DateTimeOffset.UtcNow,
+            timerInfo.ScheduleStatus?.Next);
+
+        var result = await processStationHistoryService.ProcessAsync(cancellationToken);
+
+        logger.LogInformation(
+            "ProcessStationHistory completed. Processed {JourneyCount} journeys from {SourceCount} sources into {StationCount} destination profiles.",
+            result.JourneyCount,
+            result.SourceCount,
+            result.StationCount);
+    }
+}

--- a/src/HslBikeDataAggregator/Program.cs
+++ b/src/HslBikeDataAggregator/Program.cs
@@ -21,7 +21,15 @@ builder.Services
         options.SnapshotHistoryLimit = configuration.GetValue<int?>("SnapshotHistoryLimit") ?? 60;
     });
 
+builder.Services
+    .AddOptions<HistoryProcessingOptions>()
+    .Configure<IConfiguration>((options, configuration) =>
+    {
+        options.TripHistoryUrls = configuration.GetSection("HistoryProcessing:TripHistoryUrls").Get<string[]>() ?? [];
+    });
+
 builder.Services.AddHttpClient<DigitransitStationClient>();
+builder.Services.AddHttpClient<ProcessStationHistoryService>();
 builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddSingleton(provider =>
 {

--- a/src/HslBikeDataAggregator/Services/AggregatedBikeDataService.cs
+++ b/src/HslBikeDataAggregator/Services/AggregatedBikeDataService.cs
@@ -16,5 +16,9 @@ public sealed class AggregatedBikeDataService(IBikeDataBlobStorage bikeDataBlobS
         => Task.FromResult<IReadOnlyList<HourlyAvailability>>([]);
 
     public Task<IReadOnlyList<StationHistory>> GetDestinationsAsync(string stationId, CancellationToken cancellationToken)
-        => Task.FromResult<IReadOnlyList<StationHistory>>([]);
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(stationId);
+
+        return bikeDataBlobStorage.GetStationDestinationsAsync(stationId, cancellationToken);
+    }
 }

--- a/src/HslBikeDataAggregator/Services/HistoryProcessingResult.cs
+++ b/src/HslBikeDataAggregator/Services/HistoryProcessingResult.cs
@@ -1,0 +1,10 @@
+namespace HslBikeDataAggregator.Services;
+
+public sealed record HistoryProcessingResult
+{
+    public required int SourceCount { get; init; }
+
+    public required int JourneyCount { get; init; }
+
+    public required int StationCount { get; init; }
+}

--- a/src/HslBikeDataAggregator/Services/ProcessStationHistoryService.cs
+++ b/src/HslBikeDataAggregator/Services/ProcessStationHistoryService.cs
@@ -1,0 +1,249 @@
+using System.Globalization;
+
+using HslBikeDataAggregator.Configuration;
+using HslBikeDataAggregator.Models;
+using HslBikeDataAggregator.Storage;
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace HslBikeDataAggregator.Services;
+
+public sealed class ProcessStationHistoryService(
+    HttpClient httpClient,
+    IOptions<HistoryProcessingOptions> options,
+    IBikeDataBlobStorage bikeDataBlobStorage,
+    ILogger<ProcessStationHistoryService> logger)
+{
+    private readonly string[] tripHistoryUrls = options.Value.TripHistoryUrls
+        .Where(static url => !string.IsNullOrWhiteSpace(url))
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .ToArray();
+
+    /// <summary>
+    /// Downloads configured trip history CSV sources, aggregates per-station destinations, and stores the profiles.
+    /// </summary>
+    public async Task<HistoryProcessingResult> ProcessAsync(CancellationToken cancellationToken)
+    {
+        if (tripHistoryUrls.Length == 0)
+        {
+            logger.LogWarning("No trip history URLs are configured. Skipping destination processing.");
+            return new HistoryProcessingResult
+            {
+                SourceCount = 0,
+                JourneyCount = 0,
+                StationCount = 0
+            };
+        }
+
+        var aggregates = new Dictionary<(string DepartureStationId, string ArrivalStationId), DestinationAggregate>();
+        var processedJourneyCount = 0;
+
+        foreach (var tripHistoryUrl in tripHistoryUrls)
+        {
+            processedJourneyCount += await AggregateSourceAsync(tripHistoryUrl, aggregates, cancellationToken);
+        }
+
+        var stationDestinations = new Dictionary<string, IReadOnlyList<StationHistory>>(StringComparer.Ordinal);
+        foreach (var stationGroup in aggregates.GroupBy(static aggregate => aggregate.Key.DepartureStationId, StringComparer.Ordinal))
+        {
+            stationDestinations[stationGroup.Key] = stationGroup
+                .Select(static aggregate => aggregate.Value.ToStationHistory(aggregate.Key.DepartureStationId, aggregate.Key.ArrivalStationId))
+                .OrderByDescending(static history => history.TripCount)
+                .ThenBy(static history => history.ArrivalStationId, StringComparer.Ordinal)
+                .ToArray();
+        }
+
+        foreach (var stationDestination in stationDestinations.OrderBy(static stationDestination => stationDestination.Key, StringComparer.Ordinal))
+        {
+            await bikeDataBlobStorage.WriteStationDestinationsAsync(stationDestination.Key, stationDestination.Value, cancellationToken);
+        }
+
+        logger.LogInformation(
+            "Processed {JourneyCount} historical journeys from {SourceCount} sources into {StationCount} destination profiles.",
+            processedJourneyCount,
+            tripHistoryUrls.Length,
+            stationDestinations.Count);
+
+        return new HistoryProcessingResult
+        {
+            SourceCount = tripHistoryUrls.Length,
+            JourneyCount = processedJourneyCount,
+            StationCount = stationDestinations.Count
+        };
+    }
+
+    private async Task<int> AggregateSourceAsync(
+        string sourceUrl,
+        Dictionary<(string DepartureStationId, string ArrivalStationId), DestinationAggregate> aggregates,
+        CancellationToken cancellationToken)
+    {
+        using var response = await httpClient.GetAsync(sourceUrl, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        await using var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        using var reader = new StreamReader(responseStream);
+        var headerLine = await reader.ReadLineAsync(cancellationToken);
+        if (string.IsNullOrWhiteSpace(headerLine))
+        {
+            logger.LogWarning("Trip history source {SourceUrl} was empty.", sourceUrl);
+            return 0;
+        }
+
+        var columnIndexes = GetColumnIndexes(ParseCsvLine(headerLine));
+        var processedJourneyCount = 0;
+
+        string? line;
+        while ((line = await reader.ReadLineAsync(cancellationToken)) is not null)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            if (!TryCreateJourney(ParseCsvLine(line), columnIndexes, out var journey))
+            {
+                continue;
+            }
+
+            var key = (journey.DepartureStationId, journey.ArrivalStationId);
+            if (!aggregates.TryGetValue(key, out var aggregate))
+            {
+                aggregate = new DestinationAggregate();
+                aggregates[key] = aggregate;
+            }
+
+            aggregate.Add(journey.DurationSeconds, journey.DistanceMetres);
+            processedJourneyCount++;
+        }
+
+        return processedJourneyCount;
+    }
+
+    private static TripHistoryColumnIndexes GetColumnIndexes(IReadOnlyList<string> headers)
+    {
+        var normalisedHeaders = headers
+            .Select(NormaliseHeader)
+            .ToArray();
+
+        return new TripHistoryColumnIndexes(
+            GetRequiredColumnIndex(normalisedHeaders, "departure station id"),
+            GetRequiredColumnIndex(normalisedHeaders, "return station id"),
+            GetRequiredColumnIndex(normalisedHeaders, "covered distance (m)"),
+            GetRequiredColumnIndex(normalisedHeaders, "duration (sec.)"));
+    }
+
+    private static int GetRequiredColumnIndex(IReadOnlyList<string> headers, string requiredHeader)
+    {
+        for (var index = 0; index < headers.Count; index++)
+        {
+            if (string.Equals(headers[index], requiredHeader, StringComparison.Ordinal))
+            {
+                return index;
+            }
+        }
+
+        throw new InvalidOperationException($"Trip history CSV is missing required column '{requiredHeader}'.");
+    }
+
+    private static bool TryCreateJourney(
+        IReadOnlyList<string> fields,
+        TripHistoryColumnIndexes columnIndexes,
+        out TripHistoryJourney journey)
+    {
+        journey = default;
+        if (fields.Count <= columnIndexes.DurationSeconds
+            || fields.Count <= columnIndexes.DistanceMetres
+            || fields.Count <= columnIndexes.ArrivalStationId
+            || fields.Count <= columnIndexes.DepartureStationId)
+        {
+            return false;
+        }
+
+        var departureStationId = fields[columnIndexes.DepartureStationId].Trim();
+        var arrivalStationId = fields[columnIndexes.ArrivalStationId].Trim();
+        if (string.IsNullOrWhiteSpace(departureStationId) || string.IsNullOrWhiteSpace(arrivalStationId))
+        {
+            return false;
+        }
+
+        if (!double.TryParse(fields[columnIndexes.DurationSeconds], CultureInfo.InvariantCulture, out var durationSeconds)
+            || !double.TryParse(fields[columnIndexes.DistanceMetres], CultureInfo.InvariantCulture, out var distanceMetres))
+        {
+            return false;
+        }
+
+        journey = new TripHistoryJourney(departureStationId, arrivalStationId, durationSeconds, distanceMetres);
+        return true;
+    }
+
+    private static string NormaliseHeader(string header)
+        => header.Trim().Trim('\uFEFF').Trim('"').Trim().ToLowerInvariant();
+
+    private static IReadOnlyList<string> ParseCsvLine(string line)
+    {
+        var fields = new List<string>();
+        var currentField = new System.Text.StringBuilder();
+        var inQuotes = false;
+
+        foreach (var character in line)
+        {
+            if (character == '"')
+            {
+                inQuotes = !inQuotes;
+                continue;
+            }
+
+            if (character == ',' && !inQuotes)
+            {
+                fields.Add(currentField.ToString());
+                currentField.Clear();
+                continue;
+            }
+
+            currentField.Append(character);
+        }
+
+        fields.Add(currentField.ToString());
+        return fields;
+    }
+
+    private sealed class DestinationAggregate
+    {
+        public int TripCount { get; private set; }
+
+        public double TotalDurationSeconds { get; private set; }
+
+        public double TotalDistanceMetres { get; private set; }
+
+        public void Add(double durationSeconds, double distanceMetres)
+        {
+            TripCount++;
+            TotalDurationSeconds += durationSeconds;
+            TotalDistanceMetres += distanceMetres;
+        }
+
+        public StationHistory ToStationHistory(string departureStationId, string arrivalStationId)
+            => new()
+            {
+                DepartureStationId = departureStationId,
+                ArrivalStationId = arrivalStationId,
+                TripCount = TripCount,
+                AverageDurationSeconds = TotalDurationSeconds / TripCount,
+                AverageDistanceMetres = TotalDistanceMetres / TripCount
+            };
+    }
+
+    private readonly record struct TripHistoryColumnIndexes(
+        int DepartureStationId,
+        int ArrivalStationId,
+        int DistanceMetres,
+        int DurationSeconds);
+
+    private readonly record struct TripHistoryJourney(
+        string DepartureStationId,
+        string ArrivalStationId,
+        double DurationSeconds,
+        double DistanceMetres);
+}

--- a/src/HslBikeDataAggregator/Storage/BikeDataBlobStorage.cs
+++ b/src/HslBikeDataAggregator/Storage/BikeDataBlobStorage.cs
@@ -17,6 +17,13 @@ public sealed class BikeDataBlobStorage(BlobContainerClient blobContainerClient)
     public async Task<IReadOnlyList<StationSnapshot>> GetRecentSnapshotsAsync(CancellationToken cancellationToken)
         => await ReadBlobAsync<StationSnapshot>(BikeDataBlobNames.RecentSnapshots, cancellationToken);
 
+    public Task<IReadOnlyList<StationHistory>> GetStationDestinationsAsync(string stationId, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(stationId);
+
+        return ReadBlobAsync<StationHistory>(BikeDataBlobNames.DestinationProfile(stationId), cancellationToken);
+    }
+
     private async Task<IReadOnlyList<T>> ReadBlobAsync<T>(string blobName, CancellationToken cancellationToken)
     {
         await blobContainerClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
@@ -53,5 +60,16 @@ public sealed class BikeDataBlobStorage(BlobContainerClient blobContainerClient)
         await blobContainerClient
             .GetBlobClient(BikeDataBlobNames.RecentSnapshots)
             .UploadAsync(BinaryData.FromObjectAsJson(snapshots, SerializerOptions), overwrite: true, cancellationToken);
+    }
+
+    public async Task WriteStationDestinationsAsync(string stationId, IReadOnlyList<StationHistory> destinations, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(stationId);
+        ArgumentNullException.ThrowIfNull(destinations);
+
+        await blobContainerClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
+        await blobContainerClient
+            .GetBlobClient(BikeDataBlobNames.DestinationProfile(stationId))
+            .UploadAsync(BinaryData.FromObjectAsJson(destinations, SerializerOptions), overwrite: true, cancellationToken);
     }
 }

--- a/src/HslBikeDataAggregator/Storage/IBikeDataBlobStorage.cs
+++ b/src/HslBikeDataAggregator/Storage/IBikeDataBlobStorage.cs
@@ -8,7 +8,11 @@ public interface IBikeDataBlobStorage
 
     Task<IReadOnlyList<StationSnapshot>> GetRecentSnapshotsAsync(CancellationToken cancellationToken);
 
+    Task<IReadOnlyList<StationHistory>> GetStationDestinationsAsync(string stationId, CancellationToken cancellationToken);
+
     Task WriteLatestStationsAsync(IReadOnlyList<BikeStation> stations, CancellationToken cancellationToken);
 
     Task WriteRecentSnapshotsAsync(IReadOnlyList<StationSnapshot> snapshots, CancellationToken cancellationToken);
+
+    Task WriteStationDestinationsAsync(string stationId, IReadOnlyList<StationHistory> destinations, CancellationToken cancellationToken);
 }

--- a/tests/HslBikeDataAggregator.Tests/Functions/ProcessStationHistoryFunctionTests.cs
+++ b/tests/HslBikeDataAggregator.Tests/Functions/ProcessStationHistoryFunctionTests.cs
@@ -1,0 +1,24 @@
+using System.Reflection;
+
+using HslBikeDataAggregator.Functions;
+
+using Microsoft.Azure.Functions.Worker;
+
+namespace HslBikeDataAggregator.Tests.Functions;
+
+public sealed class ProcessStationHistoryFunctionTests
+{
+    [Fact]
+    public void ProcessStationHistory_UsesConfiguredCronExpression()
+    {
+        var method = typeof(ProcessStationHistoryFunction).GetMethod(nameof(ProcessStationHistoryFunction.ProcessStationHistory), BindingFlags.Instance | BindingFlags.Public);
+
+        Assert.NotNull(method);
+
+        var timerParameter = method!.GetParameters()[0];
+        var timerTriggerAttribute = timerParameter.GetCustomAttribute<TimerTriggerAttribute>();
+
+        Assert.NotNull(timerTriggerAttribute);
+        Assert.Equal("%HistoryProcessingCron%", timerTriggerAttribute!.Schedule);
+    }
+}

--- a/tests/HslBikeDataAggregator.Tests/Functions/StationsFunctionsTests.cs
+++ b/tests/HslBikeDataAggregator.Tests/Functions/StationsFunctionsTests.cs
@@ -136,4 +136,61 @@ public sealed class StationsFunctionsTests
         using var reader = new StreamReader(responseData.Body);
         Assert.Equal("[{\"timestamp\":\"2026-04-04T09:45:00+00:00\",\"bikeCounts\":{\"station-001\":8,\"station-002\":3}}]", await reader.ReadToEndAsync(cancellationToken));
     }
+
+    [Fact]
+    public async Task GetStationDestinations_ReturnsOkResponseWithStoredDestinations()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var services = new ServiceCollection();
+        services
+            .AddOptions<WorkerOptions>()
+            .Configure(options => options.Serializer = new JsonObjectSerializer());
+
+        var serviceProvider = services.BuildServiceProvider();
+
+        var functionContext = new Mock<FunctionContext>();
+        functionContext.SetupProperty(context => context.InstanceServices, serviceProvider);
+
+        var responseHeaders = new HttpHeadersCollection();
+        var responseBody = new MemoryStream();
+        var response = new Mock<HttpResponseData>(functionContext.Object);
+        response.SetupProperty(httpResponse => httpResponse.StatusCode);
+        response.SetupProperty(httpResponse => httpResponse.Body, responseBody);
+        response.SetupGet(httpResponse => httpResponse.Headers).Returns(responseHeaders);
+        response.SetupGet(httpResponse => httpResponse.Cookies).Returns(Mock.Of<HttpCookies>());
+
+        var request = new Mock<HttpRequestData>(functionContext.Object);
+        request.Setup(httpRequest => httpRequest.CreateResponse()).Returns(response.Object);
+        request.SetupGet(httpRequest => httpRequest.Body).Returns(Stream.Null);
+        request.SetupGet(httpRequest => httpRequest.Headers).Returns(new HttpHeadersCollection());
+        request.SetupGet(httpRequest => httpRequest.Identities).Returns(Array.Empty<ClaimsIdentity>());
+        request.SetupGet(httpRequest => httpRequest.Method).Returns("GET");
+        request.SetupGet(httpRequest => httpRequest.Url).Returns(new Uri("https://localhost/api/stations/station-001/destinations"));
+
+        var blobStorage = new Mock<IBikeDataBlobStorage>();
+        blobStorage
+            .Setup(storage => storage.GetStationDestinationsAsync("station-001", cancellationToken))
+            .ReturnsAsync([
+                new StationHistory
+                {
+                    DepartureStationId = "station-001",
+                    ArrivalStationId = "station-002",
+                    TripCount = 12,
+                    AverageDurationSeconds = 425.5,
+                    AverageDistanceMetres = 1_280.2
+                }
+            ]);
+
+        var function = new StationsFunctions(new AggregatedBikeDataService(blobStorage.Object), NullLogger<StationsFunctions>.Instance);
+
+        var responseData = await function.GetStationDestinations(request.Object, "station-001", cancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, responseData.StatusCode);
+        Assert.True(responseData.Headers.TryGetValues("Access-Control-Allow-Origin", out var origins));
+        Assert.Contains("https://kuoste.github.io", origins);
+
+        responseData.Body.Position = 0;
+        using var reader = new StreamReader(responseData.Body);
+        Assert.Equal("[{\"departureStationId\":\"station-001\",\"arrivalStationId\":\"station-002\",\"tripCount\":12,\"averageDurationSeconds\":425.5,\"averageDistanceMetres\":1280.2}]", await reader.ReadToEndAsync(cancellationToken));
+    }
 }

--- a/tests/HslBikeDataAggregator.Tests/Services/AggregatedBikeDataServiceTests.cs
+++ b/tests/HslBikeDataAggregator.Tests/Services/AggregatedBikeDataServiceTests.cs
@@ -104,12 +104,27 @@ public sealed class AggregatedBikeDataServiceTests
     }
 
     [Fact]
-    public async Task GetDestinationsAsync_ReturnsEmptyCollection()
+    public async Task GetDestinationsAsync_ReturnsDestinationsFromBlobStorage()
     {
-        var service = new AggregatedBikeDataService(Mock.Of<IBikeDataBlobStorage>());
+        var blobStorage = new Mock<IBikeDataBlobStorage>();
+        blobStorage
+            .Setup(storage => storage.GetStationDestinationsAsync("station-001", CancellationToken))
+            .ReturnsAsync([
+                new StationHistory
+                {
+                    DepartureStationId = "station-001",
+                    ArrivalStationId = "station-002",
+                    TripCount = 12,
+                    AverageDurationSeconds = 425.5,
+                    AverageDistanceMetres = 1_280.2
+                }
+            ]);
+
+        var service = new AggregatedBikeDataService(blobStorage.Object);
 
         var result = await service.GetDestinationsAsync("station-001", CancellationToken);
 
-        Assert.Empty(result);
+        var destination = Assert.Single(result);
+        Assert.Equal("station-002", destination.ArrivalStationId);
     }
 }

--- a/tests/HslBikeDataAggregator.Tests/Services/ProcessStationHistoryServiceTests.cs
+++ b/tests/HslBikeDataAggregator.Tests/Services/ProcessStationHistoryServiceTests.cs
@@ -1,0 +1,103 @@
+using System.Net;
+using System.Text;
+
+using HslBikeDataAggregator.Configuration;
+using HslBikeDataAggregator.Models;
+using HslBikeDataAggregator.Services;
+using HslBikeDataAggregator.Storage;
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+using Moq;
+
+namespace HslBikeDataAggregator.Tests.Services;
+
+public sealed class ProcessStationHistoryServiceTests
+{
+    [Fact]
+    public async Task ProcessAsync_AggregatesTripsByDepartureStationAndWritesSortedDestinations()
+    {
+        var responsesByUrl = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["https://example.test/history-1.csv"] =
+                """
+                Departure station id,Return station id,Covered distance (m),Duration (sec.)
+                001,002,1200,300
+                001,002,1400,360
+                """,
+            ["https://example.test/history-2.csv"] =
+                """
+                Departure station id,Return station id,Covered distance (m),Duration (sec.)
+                001,003,800,240
+                002,001,1000,420
+                """
+        };
+
+        var handler = new StubHttpMessageHandler(request =>
+        {
+            var url = request.RequestUri?.ToString();
+            Assert.NotNull(url);
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(responsesByUrl[url!], Encoding.UTF8, "text/csv")
+            });
+        });
+
+        var options = Options.Create(new HistoryProcessingOptions
+        {
+            TripHistoryUrls = ["https://example.test/history-1.csv", "https://example.test/history-2.csv"]
+        });
+
+        var writtenDestinations = new Dictionary<string, IReadOnlyList<StationHistory>>(StringComparer.Ordinal);
+        var blobStorage = new Mock<IBikeDataBlobStorage>();
+        blobStorage
+            .Setup(storage => storage.WriteStationDestinationsAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<StationHistory>>(), It.IsAny<CancellationToken>()))
+            .Callback<string, IReadOnlyList<StationHistory>, CancellationToken>((stationId, destinations, _) => writtenDestinations[stationId] = destinations)
+            .Returns(Task.CompletedTask);
+
+        var service = new ProcessStationHistoryService(
+            new HttpClient(handler),
+            options,
+            blobStorage.Object,
+            NullLogger<ProcessStationHistoryService>.Instance);
+
+        var result = await service.ProcessAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, result.SourceCount);
+        Assert.Equal(4, result.JourneyCount);
+        Assert.Equal(2, result.StationCount);
+
+        var station001Destinations = Assert.IsAssignableFrom<IReadOnlyList<StationHistory>>(writtenDestinations["001"]);
+        Assert.Collection(
+            station001Destinations,
+            destination =>
+            {
+                Assert.Equal("001", destination.DepartureStationId);
+                Assert.Equal("002", destination.ArrivalStationId);
+                Assert.Equal(2, destination.TripCount);
+                Assert.Equal(330, destination.AverageDurationSeconds);
+                Assert.Equal(1300, destination.AverageDistanceMetres);
+            },
+            destination =>
+            {
+                Assert.Equal("001", destination.DepartureStationId);
+                Assert.Equal("003", destination.ArrivalStationId);
+                Assert.Equal(1, destination.TripCount);
+                Assert.Equal(240, destination.AverageDurationSeconds);
+                Assert.Equal(800, destination.AverageDistanceMetres);
+            });
+
+        var station002Destinations = Assert.IsAssignableFrom<IReadOnlyList<StationHistory>>(writtenDestinations["002"]);
+        var station002Destination = Assert.Single(station002Destinations);
+        Assert.Equal("001", station002Destination.ArrivalStationId);
+        Assert.Equal(1, station002Destination.TripCount);
+    }
+
+    private sealed class StubHttpMessageHandler(Func<HttpRequestMessage, Task<HttpResponseMessage>> handler) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => handler(request);
+    }
+}


### PR DESCRIPTION
## Summary
- add storage-backed destination profile reads for `GET /api/stations/{id}/destinations`
- add scheduled HSL trip history processing to aggregate per-station destination data from configured CSV sources
- add automated tests for the destination endpoint, aggregation service, and history processing trigger

## Validation
- `dotnet build HslBikeDataAggregator.slnx`
- relevant automated tests passed

Closes #5