### PR TITLE
Use rolling two-month destination window

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -80,6 +80,19 @@ jobs:
               --name "$AZURE_FUNCTION_APP_NAME" \
               --settings DigitransitSubscriptionKey="${{ secrets.DIGITRANSIT_SUBSCRIPTION_KEY }}"
 
+      - name: Configure history processing settings
+        uses: azure/cli@v2
+        with:
+          inlineScript: |
+            az functionapp config appsettings set \
+              --resource-group "$AZURE_RESOURCE_GROUP" \
+              --name "$AZURE_FUNCTION_APP_NAME" \
+              --settings \
+              HistoryProcessingCron="${{ vars.HISTORY_PROCESSING_CRON || '0 0 2 * * *' }}" \
+              HistoryProcessing__TripHistoryUrls__0="${{ vars.HISTORY_TRIP_HISTORY_URL_0 || '' }}" \
+              HistoryProcessing__TripHistoryUrls__1="${{ vars.HISTORY_TRIP_HISTORY_URL_1 || '' }}" \
+              HistoryProcessing__TripHistoryUrls__2="${{ vars.HISTORY_TRIP_HISTORY_URL_2 || '' }}"
+
       - name: Deploy Function App package
         uses: Azure/functions-action@v1
         with:

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -87,11 +87,7 @@ jobs:
             az functionapp config appsettings set \
               --resource-group "$AZURE_RESOURCE_GROUP" \
               --name "$AZURE_FUNCTION_APP_NAME" \
-              --settings \
-              HistoryProcessingCron="${{ vars.HISTORY_PROCESSING_CRON || '0 0 2 * * *' }}" \
-              HistoryProcessing__TripHistoryUrls__0="${{ vars.HISTORY_TRIP_HISTORY_URL_0 || '' }}" \
-              HistoryProcessing__TripHistoryUrls__1="${{ vars.HISTORY_TRIP_HISTORY_URL_1 || '' }}" \
-              HistoryProcessing__TripHistoryUrls__2="${{ vars.HISTORY_TRIP_HISTORY_URL_2 || '' }}"
+              --settings HistoryProcessingCron="${{ vars.HISTORY_PROCESSING_CRON || '0 0 2 * * *' }}"
 
       - name: Deploy Function App package
         uses: Azure/functions-action@v1

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -85,6 +85,19 @@ jobs:
               --name "$AZURE_FUNCTION_APP_NAME" \
               --settings DigitransitSubscriptionKey="${{ secrets.DIGITRANSIT_SUBSCRIPTION_KEY }}"
 
+      - name: Configure history processing settings
+        uses: azure/cli@v2
+        with:
+          inlineScript: |
+            az functionapp config appsettings set \
+              --resource-group "$AZURE_RESOURCE_GROUP" \
+              --name "$AZURE_FUNCTION_APP_NAME" \
+              --settings \
+              HistoryProcessingCron="${{ vars.HISTORY_PROCESSING_CRON || '0 0 2 * * *' }}" \
+              HistoryProcessing__TripHistoryUrls__0="${{ vars.HISTORY_TRIP_HISTORY_URL_0 || '' }}" \
+              HistoryProcessing__TripHistoryUrls__1="${{ vars.HISTORY_TRIP_HISTORY_URL_1 || '' }}" \
+              HistoryProcessing__TripHistoryUrls__2="${{ vars.HISTORY_TRIP_HISTORY_URL_2 || '' }}"
+
       - name: Deploy Function App package
         uses: Azure/functions-action@v1
         with:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -92,11 +92,7 @@ jobs:
             az functionapp config appsettings set \
               --resource-group "$AZURE_RESOURCE_GROUP" \
               --name "$AZURE_FUNCTION_APP_NAME" \
-              --settings \
-              HistoryProcessingCron="${{ vars.HISTORY_PROCESSING_CRON || '0 0 2 * * *' }}" \
-              HistoryProcessing__TripHistoryUrls__0="${{ vars.HISTORY_TRIP_HISTORY_URL_0 || '' }}" \
-              HistoryProcessing__TripHistoryUrls__1="${{ vars.HISTORY_TRIP_HISTORY_URL_1 || '' }}" \
-              HistoryProcessing__TripHistoryUrls__2="${{ vars.HISTORY_TRIP_HISTORY_URL_2 || '' }}"
+              --settings HistoryProcessingCron="${{ vars.HISTORY_PROCESSING_CRON || '0 0 2 * * *' }}"
 
       - name: Deploy Function App package
         uses: Azure/functions-action@v1

--- a/infra/dev.bicepparam
+++ b/infra/dev.bicepparam
@@ -5,3 +5,4 @@ param functionAppName = 'func-hsl-bike-data-aggregator-dev'
 param corsAllowedOrigin = 'https://kuoste.github.io'
 param pollIntervalCron = '0 */5 * * * *'
 param snapshotHistoryLimit = 60
+param historyProcessingCron = '0 0 2 * * *'

--- a/infra/dev.json
+++ b/infra/dev.json
@@ -16,6 +16,9 @@
     },
     "snapshotHistoryLimit": {
       "value": 60
+    },
+    "historyProcessingCron": {
+      "value": "0 0 2 * * *"
     }
   }
 }

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -24,6 +24,9 @@ param pollIntervalCron string = '0 */5 * * * *'
 @minValue(1)
 param snapshotHistoryLimit int = 60
 
+@description('Cron expression used by the ProcessStationHistory timer trigger.')
+param historyProcessingCron string = '0 0 2 * * *'
+
 var appServicePlanName = '${functionAppName}-plan'
 var applicationInsightsName = '${functionAppName}-appi'
 var storageAccountName = take('st${toLower(replace(replace(functionAppName, '-', ''), '_', ''))}${uniqueString(resourceGroup().id)}', 24)
@@ -122,6 +125,10 @@ resource functionApp 'Microsoft.Web/sites@2023-12-01' = {
         {
           name: 'SnapshotHistoryLimit'
           value: string(snapshotHistoryLimit)
+        }
+        {
+          name: 'HistoryProcessingCron'
+          value: historyProcessingCron
         }
         {
           name: 'WEBSITE_CONTENTAZUREFILECONNECTIONSTRING'

--- a/infra/prod.bicepparam
+++ b/infra/prod.bicepparam
@@ -5,3 +5,4 @@ param functionAppName = 'func-hsl-bike-data-aggregator-prod'
 param corsAllowedOrigin = 'https://kuoste.github.io'
 param pollIntervalCron = '0 */5 * * * *'
 param snapshotHistoryLimit = 60
+param historyProcessingCron = '0 0 2 * * *'

--- a/infra/prod.json
+++ b/infra/prod.json
@@ -16,6 +16,9 @@
     },
     "snapshotHistoryLimit": {
       "value": 60
+    },
+    "historyProcessingCron": {
+      "value": "0 0 2 * * *"
     }
   }
 }

--- a/src/HslBikeDataAggregator/Configuration/HistoryProcessingOptions.cs
+++ b/src/HslBikeDataAggregator/Configuration/HistoryProcessingOptions.cs
@@ -2,5 +2,13 @@ namespace HslBikeDataAggregator.Configuration;
 
 public sealed class HistoryProcessingOptions
 {
-    public string[] TripHistoryUrls { get; set; } = [];
+    public const string DefaultTripHistoryUrlPattern = "https://dev.hsl.fi/citybikes/od-trips-{0:yyyy}/{0:yyyy-MM}.csv";
+    public const int DefaultRollingWindowMonthCount = 2;
+    public const int DefaultAvailabilityProbeMonthCount = 12;
+
+    public string TripHistoryUrlPattern { get; set; } = DefaultTripHistoryUrlPattern;
+
+    public int RollingWindowMonthCount { get; set; } = DefaultRollingWindowMonthCount;
+
+    public int AvailabilityProbeMonthCount { get; set; } = DefaultAvailabilityProbeMonthCount;
 }

--- a/src/HslBikeDataAggregator/Program.cs
+++ b/src/HslBikeDataAggregator/Program.cs
@@ -25,7 +25,13 @@ builder.Services
     .AddOptions<HistoryProcessingOptions>()
     .Configure<IConfiguration>((options, configuration) =>
     {
-        options.TripHistoryUrls = configuration.GetSection("HistoryProcessing:TripHistoryUrls").Get<string[]>() ?? [];
+        options.TripHistoryUrlPattern = configuration["HistoryProcessing:TripHistoryUrlPattern"] ?? HistoryProcessingOptions.DefaultTripHistoryUrlPattern;
+        options.RollingWindowMonthCount = Math.Max(
+            configuration.GetValue<int?>("HistoryProcessing:RollingWindowMonthCount") ?? HistoryProcessingOptions.DefaultRollingWindowMonthCount,
+            1);
+        options.AvailabilityProbeMonthCount = Math.Max(
+            configuration.GetValue<int?>("HistoryProcessing:AvailabilityProbeMonthCount") ?? HistoryProcessingOptions.DefaultAvailabilityProbeMonthCount,
+            options.RollingWindowMonthCount);
     });
 
 builder.Services.AddHttpClient<DigitransitStationClient>();

--- a/src/HslBikeDataAggregator/Services/ProcessStationHistoryService.cs
+++ b/src/HslBikeDataAggregator/Services/ProcessStationHistoryService.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Net;
 
 using HslBikeDataAggregator.Configuration;
 using HslBikeDataAggregator.Models;
@@ -13,21 +14,24 @@ public sealed class ProcessStationHistoryService(
     HttpClient httpClient,
     IOptions<HistoryProcessingOptions> options,
     IBikeDataBlobStorage bikeDataBlobStorage,
+    TimeProvider timeProvider,
     ILogger<ProcessStationHistoryService> logger)
 {
-    private readonly string[] tripHistoryUrls = options.Value.TripHistoryUrls
-        .Where(static url => !string.IsNullOrWhiteSpace(url))
-        .Distinct(StringComparer.OrdinalIgnoreCase)
-        .ToArray();
+    private readonly string tripHistoryUrlPattern = string.IsNullOrWhiteSpace(options.Value.TripHistoryUrlPattern)
+        ? HistoryProcessingOptions.DefaultTripHistoryUrlPattern
+        : options.Value.TripHistoryUrlPattern;
+    private readonly int rollingWindowMonthCount = Math.Max(options.Value.RollingWindowMonthCount, 1);
+    private readonly int availabilityProbeMonthCount = Math.Max(options.Value.AvailabilityProbeMonthCount, Math.Max(options.Value.RollingWindowMonthCount, 1));
 
     /// <summary>
-    /// Downloads configured trip history CSV sources, aggregates per-station destinations, and stores the profiles.
+    /// Discovers the newest available HSL trip history CSV files, aggregates a rolling destination window, and stores the profiles.
     /// </summary>
     public async Task<HistoryProcessingResult> ProcessAsync(CancellationToken cancellationToken)
     {
-        if (tripHistoryUrls.Length == 0)
+        var availableMonths = await DiscoverAvailableMonthsAsync(cancellationToken);
+        if (availableMonths.Count == 0)
         {
-            logger.LogWarning("No trip history URLs are configured. Skipping destination processing.");
+            logger.LogWarning("No recent HSL trip history CSV files were available. Skipping destination processing.");
             return new HistoryProcessingResult
             {
                 SourceCount = 0,
@@ -39,9 +43,9 @@ public sealed class ProcessStationHistoryService(
         var aggregates = new Dictionary<(string DepartureStationId, string ArrivalStationId), DestinationAggregate>();
         var processedJourneyCount = 0;
 
-        foreach (var tripHistoryUrl in tripHistoryUrls)
+        foreach (var availableMonth in availableMonths)
         {
-            processedJourneyCount += await AggregateSourceAsync(tripHistoryUrl, aggregates, cancellationToken);
+            processedJourneyCount += await AggregateSourceAsync(BuildTripHistoryUrl(availableMonth), aggregates, cancellationToken);
         }
 
         var stationDestinations = new Dictionary<string, IReadOnlyList<StationHistory>>(StringComparer.Ordinal);
@@ -59,19 +63,59 @@ public sealed class ProcessStationHistoryService(
             await bikeDataBlobStorage.WriteStationDestinationsAsync(stationDestination.Key, stationDestination.Value, cancellationToken);
         }
 
+        var currentStationIds = stationDestinations.Keys.ToHashSet(StringComparer.Ordinal);
+        var existingStationIds = await bikeDataBlobStorage.ListStationDestinationIdsAsync(cancellationToken);
+        foreach (var staleStationId in existingStationIds.Except(currentStationIds, StringComparer.Ordinal).OrderBy(static stationId => stationId, StringComparer.Ordinal))
+        {
+            await bikeDataBlobStorage.DeleteStationDestinationsAsync(staleStationId, cancellationToken);
+        }
+
         logger.LogInformation(
-            "Processed {JourneyCount} historical journeys from {SourceCount} sources into {StationCount} destination profiles.",
+            "Processed {JourneyCount} historical journeys from {SourceCount} sources into {StationCount} destination profiles for months {Months}.",
             processedJourneyCount,
-            tripHistoryUrls.Length,
-            stationDestinations.Count);
+            availableMonths.Count,
+            stationDestinations.Count,
+            string.Join(", ", availableMonths.Select(static month => $"{month:yyyy-MM}")));
 
         return new HistoryProcessingResult
         {
-            SourceCount = tripHistoryUrls.Length,
+            SourceCount = availableMonths.Count,
             JourneyCount = processedJourneyCount,
             StationCount = stationDestinations.Count
         };
     }
+
+    private async Task<IReadOnlyList<DateOnly>> DiscoverAvailableMonthsAsync(CancellationToken cancellationToken)
+    {
+        var newestCandidateMonth = new DateOnly(timeProvider.GetUtcNow().Year, timeProvider.GetUtcNow().Month, 1);
+        var availableMonths = new List<DateOnly>(rollingWindowMonthCount);
+
+        for (var monthOffset = 0; monthOffset < availabilityProbeMonthCount && availableMonths.Count < rollingWindowMonthCount; monthOffset++)
+        {
+            var candidateMonth = newestCandidateMonth.AddMonths(-monthOffset);
+            if (await TripHistoryMonthExistsAsync(candidateMonth, cancellationToken))
+            {
+                availableMonths.Add(candidateMonth);
+            }
+        }
+
+        return availableMonths;
+    }
+
+    private async Task<bool> TripHistoryMonthExistsAsync(DateOnly month, CancellationToken cancellationToken)
+    {
+        using var response = await httpClient.GetAsync(BuildTripHistoryUrl(month), HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            return false;
+        }
+
+        response.EnsureSuccessStatusCode();
+        return true;
+    }
+
+    private string BuildTripHistoryUrl(DateOnly month)
+        => string.Format(CultureInfo.InvariantCulture, tripHistoryUrlPattern, month.ToDateTime(TimeOnly.MinValue));
 
     private async Task<int> AggregateSourceAsync(
         string sourceUrl,

--- a/src/HslBikeDataAggregator/Storage/BikeDataBlobStorage.cs
+++ b/src/HslBikeDataAggregator/Storage/BikeDataBlobStorage.cs
@@ -24,6 +24,27 @@ public sealed class BikeDataBlobStorage(BlobContainerClient blobContainerClient)
         return ReadBlobAsync<StationHistory>(BikeDataBlobNames.DestinationProfile(stationId), cancellationToken);
     }
 
+    public async Task<IReadOnlyList<string>> ListStationDestinationIdsAsync(CancellationToken cancellationToken)
+    {
+        await blobContainerClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
+
+        var stationIds = new List<string>();
+        await foreach (var blobItem in blobContainerClient.GetBlobsAsync(prefix: "destinations/", cancellationToken: cancellationToken))
+        {
+            const string prefix = "destinations/";
+            const string suffix = ".json";
+            if (!blobItem.Name.StartsWith(prefix, StringComparison.Ordinal)
+                || !blobItem.Name.EndsWith(suffix, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            stationIds.Add(blobItem.Name[prefix.Length..^suffix.Length]);
+        }
+
+        return stationIds;
+    }
+
     private async Task<IReadOnlyList<T>> ReadBlobAsync<T>(string blobName, CancellationToken cancellationToken)
     {
         await blobContainerClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
@@ -71,5 +92,15 @@ public sealed class BikeDataBlobStorage(BlobContainerClient blobContainerClient)
         await blobContainerClient
             .GetBlobClient(BikeDataBlobNames.DestinationProfile(stationId))
             .UploadAsync(BinaryData.FromObjectAsJson(destinations, SerializerOptions), overwrite: true, cancellationToken);
+    }
+
+    public async Task DeleteStationDestinationsAsync(string stationId, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(stationId);
+
+        await blobContainerClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
+        await blobContainerClient
+            .GetBlobClient(BikeDataBlobNames.DestinationProfile(stationId))
+            .DeleteIfExistsAsync(cancellationToken: cancellationToken);
     }
 }

--- a/src/HslBikeDataAggregator/Storage/IBikeDataBlobStorage.cs
+++ b/src/HslBikeDataAggregator/Storage/IBikeDataBlobStorage.cs
@@ -10,9 +10,13 @@ public interface IBikeDataBlobStorage
 
     Task<IReadOnlyList<StationHistory>> GetStationDestinationsAsync(string stationId, CancellationToken cancellationToken);
 
+    Task<IReadOnlyList<string>> ListStationDestinationIdsAsync(CancellationToken cancellationToken);
+
     Task WriteLatestStationsAsync(IReadOnlyList<BikeStation> stations, CancellationToken cancellationToken);
 
     Task WriteRecentSnapshotsAsync(IReadOnlyList<StationSnapshot> snapshots, CancellationToken cancellationToken);
 
     Task WriteStationDestinationsAsync(string stationId, IReadOnlyList<StationHistory> destinations, CancellationToken cancellationToken);
+
+    Task DeleteStationDestinationsAsync(string stationId, CancellationToken cancellationToken);
 }

--- a/tests/HslBikeDataAggregator.Tests/Configuration/DeploymentWorkflowConfigurationTests.cs
+++ b/tests/HslBikeDataAggregator.Tests/Configuration/DeploymentWorkflowConfigurationTests.cs
@@ -59,6 +59,19 @@ public sealed class DeploymentWorkflowConfigurationTests
     }
 
     [Fact]
+    public async Task DeployWorkflows_ConfigureHistoryProcessingSettings()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var devYaml = await File.ReadAllTextAsync(GetRepositoryFilePath(".github", "workflows", "deploy-dev.yml"), cancellationToken);
+        var prodYaml = await File.ReadAllTextAsync(GetRepositoryFilePath(".github", "workflows", "deploy-prod.yml"), cancellationToken);
+
+        Assert.Contains("HistoryProcessingCron", devYaml, StringComparison.Ordinal);
+        Assert.Contains("HistoryProcessing__TripHistoryUrls__0", devYaml, StringComparison.Ordinal);
+        Assert.Contains("HistoryProcessingCron", prodYaml, StringComparison.Ordinal);
+        Assert.Contains("HistoryProcessing__TripHistoryUrls__0", prodYaml, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task BicepParameterFiles_ContainRecommendedFunctionAppNames()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
@@ -67,6 +80,24 @@ public sealed class DeploymentWorkflowConfigurationTests
 
         Assert.Contains("func-hsl-bike-data-aggregator-dev", devParameters, StringComparison.Ordinal);
         Assert.Contains("func-hsl-bike-data-aggregator-prod", prodParameters, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task InfrastructureParameters_ContainHistoryProcessingCronDefaults()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var mainBicep = await File.ReadAllTextAsync(GetRepositoryFilePath("infra", "main.bicep"), cancellationToken);
+        var devJson = await File.ReadAllTextAsync(GetRepositoryFilePath("infra", "dev.json"), cancellationToken);
+        var prodJson = await File.ReadAllTextAsync(GetRepositoryFilePath("infra", "prod.json"), cancellationToken);
+        var devBicepParameters = await File.ReadAllTextAsync(GetRepositoryFilePath("infra", "dev.bicepparam"), cancellationToken);
+        var prodBicepParameters = await File.ReadAllTextAsync(GetRepositoryFilePath("infra", "prod.bicepparam"), cancellationToken);
+
+        Assert.Contains("param historyProcessingCron string", mainBicep, StringComparison.Ordinal);
+        Assert.Contains("name: 'HistoryProcessingCron'", mainBicep, StringComparison.Ordinal);
+        Assert.Contains("\"historyProcessingCron\"", devJson, StringComparison.Ordinal);
+        Assert.Contains("\"historyProcessingCron\"", prodJson, StringComparison.Ordinal);
+        Assert.Contains("param historyProcessingCron = '0 0 2 * * *'", devBicepParameters, StringComparison.Ordinal);
+        Assert.Contains("param historyProcessingCron = '0 0 2 * * *'", prodBicepParameters, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/HslBikeDataAggregator.Tests/Configuration/DeploymentWorkflowConfigurationTests.cs
+++ b/tests/HslBikeDataAggregator.Tests/Configuration/DeploymentWorkflowConfigurationTests.cs
@@ -66,9 +66,9 @@ public sealed class DeploymentWorkflowConfigurationTests
         var prodYaml = await File.ReadAllTextAsync(GetRepositoryFilePath(".github", "workflows", "deploy-prod.yml"), cancellationToken);
 
         Assert.Contains("HistoryProcessingCron", devYaml, StringComparison.Ordinal);
-        Assert.Contains("HistoryProcessing__TripHistoryUrls__0", devYaml, StringComparison.Ordinal);
+        Assert.DoesNotContain("HistoryProcessing__TripHistoryUrls__0", devYaml, StringComparison.Ordinal);
         Assert.Contains("HistoryProcessingCron", prodYaml, StringComparison.Ordinal);
-        Assert.Contains("HistoryProcessing__TripHistoryUrls__0", prodYaml, StringComparison.Ordinal);
+        Assert.DoesNotContain("HistoryProcessing__TripHistoryUrls__0", prodYaml, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/HslBikeDataAggregator.Tests/Services/ProcessStationHistoryServiceTests.cs
+++ b/tests/HslBikeDataAggregator.Tests/Services/ProcessStationHistoryServiceTests.cs
@@ -16,42 +16,51 @@ namespace HslBikeDataAggregator.Tests.Services;
 public sealed class ProcessStationHistoryServiceTests
 {
     [Fact]
-    public async Task ProcessAsync_AggregatesTripsByDepartureStationAndWritesSortedDestinations()
+    public async Task ProcessAsync_UsesOnlyNewestTwoAvailableMonths()
     {
-        var responsesByUrl = new Dictionary<string, string>(StringComparer.Ordinal)
-        {
-            ["https://example.test/history-1.csv"] =
-                """
-                Departure station id,Return station id,Covered distance (m),Duration (sec.)
-                001,002,1200,300
-                001,002,1400,360
-                """,
-            ["https://example.test/history-2.csv"] =
-                """
-                Departure station id,Return station id,Covered distance (m),Duration (sec.)
-                001,003,800,240
-                002,001,1000,420
-                """
-        };
-
+        var requestedUrls = new List<string>();
         var handler = new StubHttpMessageHandler(request =>
         {
             var url = request.RequestUri?.ToString();
             Assert.NotNull(url);
+            requestedUrls.Add(url!);
 
-            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            return Task.FromResult(url switch
             {
-                Content = new StringContent(responsesByUrl[url!], Encoding.UTF8, "text/csv")
+                "https://example.test/2024-07.csv" => CreateResponse(
+                    HttpStatusCode.OK,
+                    """
+                    Departure station id,Return station id,Covered distance (m),Duration (sec.)
+                    001,002,1200,300
+                    """),
+                "https://example.test/2024-06.csv" => CreateResponse(
+                    HttpStatusCode.OK,
+                    """
+                    Departure station id,Return station id,Covered distance (m),Duration (sec.)
+                    001,003,800,240
+                    """),
+                "https://example.test/2024-05.csv" => CreateResponse(
+                    HttpStatusCode.OK,
+                    """
+                    Departure station id,Return station id,Covered distance (m),Duration (sec.)
+                    001,004,900,260
+                    """),
+                _ => CreateResponse(HttpStatusCode.NotFound)
             });
         });
 
         var options = Options.Create(new HistoryProcessingOptions
         {
-            TripHistoryUrls = ["https://example.test/history-1.csv", "https://example.test/history-2.csv"]
+            TripHistoryUrlPattern = "https://example.test/{0:yyyy-MM}.csv",
+            RollingWindowMonthCount = 2,
+            AvailabilityProbeMonthCount = 6
         });
 
         var writtenDestinations = new Dictionary<string, IReadOnlyList<StationHistory>>(StringComparer.Ordinal);
         var blobStorage = new Mock<IBikeDataBlobStorage>();
+        blobStorage
+            .Setup(storage => storage.ListStationDestinationIdsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
         blobStorage
             .Setup(storage => storage.WriteStationDestinationsAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<StationHistory>>(), It.IsAny<CancellationToken>()))
             .Callback<string, IReadOnlyList<StationHistory>, CancellationToken>((stationId, destinations, _) => writtenDestinations[stationId] = destinations)
@@ -61,43 +70,170 @@ public sealed class ProcessStationHistoryServiceTests
             new HttpClient(handler),
             options,
             blobStorage.Object,
+            new FixedTimeProvider(new DateTimeOffset(2024, 7, 15, 0, 0, 0, TimeSpan.Zero)),
             NullLogger<ProcessStationHistoryService>.Instance);
 
         var result = await service.ProcessAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(2, result.SourceCount);
-        Assert.Equal(4, result.JourneyCount);
-        Assert.Equal(2, result.StationCount);
+        Assert.Equal(2, result.JourneyCount);
+        Assert.Equal(1, result.StationCount);
 
         var station001Destinations = Assert.IsAssignableFrom<IReadOnlyList<StationHistory>>(writtenDestinations["001"]);
         Assert.Collection(
             station001Destinations,
             destination =>
             {
-                Assert.Equal("001", destination.DepartureStationId);
                 Assert.Equal("002", destination.ArrivalStationId);
-                Assert.Equal(2, destination.TripCount);
-                Assert.Equal(330, destination.AverageDurationSeconds);
-                Assert.Equal(1300, destination.AverageDistanceMetres);
+                Assert.Equal(1, destination.TripCount);
             },
             destination =>
             {
-                Assert.Equal("001", destination.DepartureStationId);
                 Assert.Equal("003", destination.ArrivalStationId);
                 Assert.Equal(1, destination.TripCount);
-                Assert.Equal(240, destination.AverageDurationSeconds);
-                Assert.Equal(800, destination.AverageDistanceMetres);
             });
+
+        Assert.DoesNotContain("https://example.test/2024-05.csv", requestedUrls, StringComparer.Ordinal);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_SearchesBackwardsAndDeletesStaleDestinationProfiles()
+    {
+        var requestedUrls = new List<string>();
+        var handler = new StubHttpMessageHandler(request =>
+        {
+            var url = request.RequestUri?.ToString();
+            Assert.NotNull(url);
+            requestedUrls.Add(url!);
+
+            return Task.FromResult(url switch
+            {
+                "https://example.test/2024-07.csv" => CreateResponse(HttpStatusCode.NotFound),
+                "https://example.test/2024-06.csv" => CreateResponse(
+                    HttpStatusCode.OK,
+                    """
+                    Departure station id,Return station id,Covered distance (m),Duration (sec.)
+                    001,002,1200,300
+                    001,002,1400,360
+                    """),
+                "https://example.test/2024-05.csv" => CreateResponse(
+                    HttpStatusCode.OK,
+                    """
+                    Departure station id,Return station id,Covered distance (m),Duration (sec.)
+                    002,001,1000,420
+                    """),
+                _ => CreateResponse(HttpStatusCode.NotFound)
+            });
+        });
+
+        var options = Options.Create(new HistoryProcessingOptions
+        {
+            TripHistoryUrlPattern = "https://example.test/{0:yyyy-MM}.csv",
+            RollingWindowMonthCount = 2,
+            AvailabilityProbeMonthCount = 6
+        });
+
+        var writtenDestinations = new Dictionary<string, IReadOnlyList<StationHistory>>(StringComparer.Ordinal);
+        var deletedStationIds = new List<string>();
+        var blobStorage = new Mock<IBikeDataBlobStorage>();
+        blobStorage
+            .Setup(storage => storage.ListStationDestinationIdsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(["001", "999"]);
+        blobStorage
+            .Setup(storage => storage.WriteStationDestinationsAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<StationHistory>>(), It.IsAny<CancellationToken>()))
+            .Callback<string, IReadOnlyList<StationHistory>, CancellationToken>((stationId, destinations, _) => writtenDestinations[stationId] = destinations)
+            .Returns(Task.CompletedTask);
+        blobStorage
+            .Setup(storage => storage.DeleteStationDestinationsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback<string, CancellationToken>((stationId, _) => deletedStationIds.Add(stationId))
+            .Returns(Task.CompletedTask);
+
+        var service = new ProcessStationHistoryService(
+            new HttpClient(handler),
+            options,
+            blobStorage.Object,
+            new FixedTimeProvider(new DateTimeOffset(2024, 7, 15, 0, 0, 0, TimeSpan.Zero)),
+            NullLogger<ProcessStationHistoryService>.Instance);
+
+        var result = await service.ProcessAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, result.SourceCount);
+        Assert.Equal(3, result.JourneyCount);
+        Assert.Equal(2, result.StationCount);
+
+        var station001Destinations = Assert.IsAssignableFrom<IReadOnlyList<StationHistory>>(writtenDestinations["001"]);
+        var station001Destination = Assert.Single(station001Destinations);
+        Assert.Equal("002", station001Destination.ArrivalStationId);
+        Assert.Equal(2, station001Destination.TripCount);
+        Assert.Equal(330, station001Destination.AverageDurationSeconds);
+        Assert.Equal(1300, station001Destination.AverageDistanceMetres);
 
         var station002Destinations = Assert.IsAssignableFrom<IReadOnlyList<StationHistory>>(writtenDestinations["002"]);
         var station002Destination = Assert.Single(station002Destinations);
         Assert.Equal("001", station002Destination.ArrivalStationId);
-        Assert.Equal(1, station002Destination.TripCount);
+
+        var deletedStationId = Assert.Single(deletedStationIds);
+        Assert.Equal("999", deletedStationId);
+
+        Assert.Contains("https://example.test/2024-07.csv", requestedUrls, StringComparer.Ordinal);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_ReturnsEmptyResultWhenNoRecentMonthsAreAvailable()
+    {
+        var handler = new StubHttpMessageHandler(request =>
+        {
+            var url = request.RequestUri?.ToString();
+            Assert.NotNull(url);
+
+            return Task.FromResult(CreateResponse(HttpStatusCode.NotFound));
+        });
+
+        var options = Options.Create(new HistoryProcessingOptions
+        {
+            TripHistoryUrlPattern = "https://example.test/{0:yyyy-MM}.csv",
+            RollingWindowMonthCount = 2,
+            AvailabilityProbeMonthCount = 3
+        });
+
+        var blobStorage = new Mock<IBikeDataBlobStorage>();
+        var service = new ProcessStationHistoryService(
+            new HttpClient(handler),
+            options,
+            blobStorage.Object,
+            new FixedTimeProvider(new DateTimeOffset(2024, 7, 15, 0, 0, 0, TimeSpan.Zero)),
+            NullLogger<ProcessStationHistoryService>.Instance);
+
+        var result = await service.ProcessAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(0, result.SourceCount);
+        Assert.Equal(0, result.JourneyCount);
+        Assert.Equal(0, result.StationCount);
+
+        blobStorage.Verify(storage => storage.WriteStationDestinationsAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<StationHistory>>(), It.IsAny<CancellationToken>()), Times.Never);
+        blobStorage.Verify(storage => storage.ListStationDestinationIdsAsync(It.IsAny<CancellationToken>()), Times.Never);
+        blobStorage.Verify(storage => storage.DeleteStationDestinationsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    private static HttpResponseMessage CreateResponse(HttpStatusCode statusCode, string? content = null)
+    {
+        var response = new HttpResponseMessage(statusCode);
+        if (content is not null)
+        {
+            response.Content = new StringContent(content, Encoding.UTF8, "text/csv");
+        }
+
+        return response;
     }
 
     private sealed class StubHttpMessageHandler(Func<HttpRequestMessage, Task<HttpResponseMessage>> handler) : HttpMessageHandler
     {
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             => handler(request);
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset timestamp) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => timestamp;
     }
 }


### PR DESCRIPTION
## Summary
- replace fixed trip-history URL configuration with automatic HSL month discovery
- aggregate destination statistics from only the newest two available months and remove stale destination blobs
- simplify deployment settings so history processing only requires the schedule setting

## Validation
- `dotnet build HslBikeDataAggregator.slnx`
- `HslBikeDataAggregator.Tests.Services.ProcessStationHistoryServiceTests`
- `HslBikeDataAggregator.Tests.Configuration.DeploymentWorkflowConfigurationTests`

Closes #5