### PR TITLE
Compute hourly availability profiles

### DIFF
--- a/src/HslBikeDataAggregator/Program.cs
+++ b/src/HslBikeDataAggregator/Program.cs
@@ -37,6 +37,7 @@ builder.Services
 builder.Services.AddHttpClient<DigitransitStationClient>();
 builder.Services.AddHttpClient<ProcessStationHistoryService>();
 builder.Services.AddSingleton(TimeProvider.System);
+builder.Services.AddSingleton<AvailabilityProfileService>();
 builder.Services.AddSingleton(provider =>
 {
     var configuration = provider.GetRequiredService<IConfiguration>();

--- a/src/HslBikeDataAggregator/Services/AggregatedBikeDataService.cs
+++ b/src/HslBikeDataAggregator/Services/AggregatedBikeDataService.cs
@@ -13,7 +13,11 @@ public sealed class AggregatedBikeDataService(IBikeDataBlobStorage bikeDataBlobS
         => bikeDataBlobStorage.GetRecentSnapshotsAsync(cancellationToken);
 
     public Task<IReadOnlyList<HourlyAvailability>> GetAvailabilityAsync(string stationId, CancellationToken cancellationToken)
-        => Task.FromResult<IReadOnlyList<HourlyAvailability>>([]);
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(stationId);
+
+        return bikeDataBlobStorage.GetAvailabilityProfileAsync(stationId, cancellationToken);
+    }
 
     public Task<IReadOnlyList<StationHistory>> GetDestinationsAsync(string stationId, CancellationToken cancellationToken)
     {

--- a/src/HslBikeDataAggregator/Services/AvailabilityProfileService.cs
+++ b/src/HslBikeDataAggregator/Services/AvailabilityProfileService.cs
@@ -1,0 +1,37 @@
+using HslBikeDataAggregator.Models;
+
+namespace HslBikeDataAggregator.Services;
+
+public sealed class AvailabilityProfileService
+{
+    /// <summary>
+    /// Builds per-station hourly bike availability averages from stored snapshots.
+    /// </summary>
+    public IReadOnlyDictionary<string, IReadOnlyList<HourlyAvailability>> BuildProfiles(IReadOnlyList<StationSnapshot> snapshots)
+    {
+        ArgumentNullException.ThrowIfNull(snapshots);
+
+        var profiles = snapshots
+            .SelectMany(snapshot => snapshot.BikeCounts.Select(bikeCount => new SnapshotObservation(
+                bikeCount.Key,
+                snapshot.Timestamp.Hour,
+                bikeCount.Value)))
+            .GroupBy(static observation => observation.StationId, StringComparer.Ordinal)
+            .ToDictionary(
+                stationGroup => stationGroup.Key,
+                stationGroup => (IReadOnlyList<HourlyAvailability>)stationGroup
+                    .GroupBy(static observation => observation.Hour)
+                    .OrderBy(static hourGroup => hourGroup.Key)
+                    .Select(hourGroup => new HourlyAvailability
+                    {
+                        Hour = hourGroup.Key,
+                        AverageBikesAvailable = hourGroup.Average(static observation => observation.BikesAvailable)
+                    })
+                    .ToArray(),
+                StringComparer.Ordinal);
+
+        return profiles;
+    }
+
+    private readonly record struct SnapshotObservation(string StationId, int Hour, int BikesAvailable);
+}

--- a/src/HslBikeDataAggregator/Services/PollStationsService.cs
+++ b/src/HslBikeDataAggregator/Services/PollStationsService.cs
@@ -10,6 +10,7 @@ namespace HslBikeDataAggregator.Services;
 public sealed class PollStationsService(
     DigitransitStationClient digitransitStationClient,
     IBikeDataBlobStorage bikeDataBlobStorage,
+    AvailabilityProfileService availabilityProfileService,
     IOptions<PollStationsOptions> options,
     TimeProvider timeProvider,
     ILogger<PollStationsService> logger) : IPollStationsService
@@ -31,14 +32,20 @@ public sealed class PollStationsService(
             .OrderBy(snapshot => snapshot.Timestamp)
             .TakeLast(snapshotHistoryLimit)
             .ToArray();
+        var availabilityProfiles = availabilityProfileService.BuildProfiles(updatedSnapshots);
 
         await bikeDataBlobStorage.WriteLatestStationsAsync(stations, cancellationToken);
         await bikeDataBlobStorage.WriteRecentSnapshotsAsync(updatedSnapshots, cancellationToken);
+        foreach (var availabilityProfile in availabilityProfiles)
+        {
+            await bikeDataBlobStorage.WriteAvailabilityProfileAsync(availabilityProfile.Key, availabilityProfile.Value, cancellationToken);
+        }
 
         logger.LogInformation(
-            "Stored {StationCount} stations and {SnapshotCount} snapshots at {Timestamp}.",
+            "Stored {StationCount} stations, {SnapshotCount} snapshots, and {AvailabilityProfileCount} hourly availability profiles at {Timestamp}.",
             stations.Count,
             updatedSnapshots.Length,
+            availabilityProfiles.Count,
             timestamp);
 
         return new PollStationsResult(timestamp, stations.Count, updatedSnapshots.Length);

--- a/src/HslBikeDataAggregator/Storage/BikeDataBlobStorage.cs
+++ b/src/HslBikeDataAggregator/Storage/BikeDataBlobStorage.cs
@@ -17,6 +17,13 @@ public sealed class BikeDataBlobStorage(BlobContainerClient blobContainerClient)
     public async Task<IReadOnlyList<StationSnapshot>> GetRecentSnapshotsAsync(CancellationToken cancellationToken)
         => await ReadBlobAsync<StationSnapshot>(BikeDataBlobNames.RecentSnapshots, cancellationToken);
 
+    public Task<IReadOnlyList<HourlyAvailability>> GetAvailabilityProfileAsync(string stationId, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(stationId);
+
+        return ReadBlobAsync<HourlyAvailability>(BikeDataBlobNames.AvailabilityProfile(stationId), cancellationToken);
+    }
+
     public Task<IReadOnlyList<StationHistory>> GetStationDestinationsAsync(string stationId, CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(stationId);
@@ -81,6 +88,17 @@ public sealed class BikeDataBlobStorage(BlobContainerClient blobContainerClient)
         await blobContainerClient
             .GetBlobClient(BikeDataBlobNames.RecentSnapshots)
             .UploadAsync(BinaryData.FromObjectAsJson(snapshots, SerializerOptions), overwrite: true, cancellationToken);
+    }
+
+    public async Task WriteAvailabilityProfileAsync(string stationId, IReadOnlyList<HourlyAvailability> availabilityProfile, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(stationId);
+        ArgumentNullException.ThrowIfNull(availabilityProfile);
+
+        await blobContainerClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
+        await blobContainerClient
+            .GetBlobClient(BikeDataBlobNames.AvailabilityProfile(stationId))
+            .UploadAsync(BinaryData.FromObjectAsJson(availabilityProfile, SerializerOptions), overwrite: true, cancellationToken);
     }
 
     public async Task WriteStationDestinationsAsync(string stationId, IReadOnlyList<StationHistory> destinations, CancellationToken cancellationToken)

--- a/src/HslBikeDataAggregator/Storage/IBikeDataBlobStorage.cs
+++ b/src/HslBikeDataAggregator/Storage/IBikeDataBlobStorage.cs
@@ -8,6 +8,8 @@ public interface IBikeDataBlobStorage
 
     Task<IReadOnlyList<StationSnapshot>> GetRecentSnapshotsAsync(CancellationToken cancellationToken);
 
+    Task<IReadOnlyList<HourlyAvailability>> GetAvailabilityProfileAsync(string stationId, CancellationToken cancellationToken);
+
     Task<IReadOnlyList<StationHistory>> GetStationDestinationsAsync(string stationId, CancellationToken cancellationToken);
 
     Task<IReadOnlyList<string>> ListStationDestinationIdsAsync(CancellationToken cancellationToken);
@@ -15,6 +17,8 @@ public interface IBikeDataBlobStorage
     Task WriteLatestStationsAsync(IReadOnlyList<BikeStation> stations, CancellationToken cancellationToken);
 
     Task WriteRecentSnapshotsAsync(IReadOnlyList<StationSnapshot> snapshots, CancellationToken cancellationToken);
+
+    Task WriteAvailabilityProfileAsync(string stationId, IReadOnlyList<HourlyAvailability> availabilityProfile, CancellationToken cancellationToken);
 
     Task WriteStationDestinationsAsync(string stationId, IReadOnlyList<StationHistory> destinations, CancellationToken cancellationToken);
 

--- a/tests/HslBikeDataAggregator.Tests/Functions/StationsFunctionsTests.cs
+++ b/tests/HslBikeDataAggregator.Tests/Functions/StationsFunctionsTests.cs
@@ -138,6 +138,65 @@ public sealed class StationsFunctionsTests
     }
 
     [Fact]
+    public async Task GetStationAvailability_ReturnsOkResponseWithStoredAvailabilityProfile()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var services = new ServiceCollection();
+        services
+            .AddOptions<WorkerOptions>()
+            .Configure(options => options.Serializer = new JsonObjectSerializer());
+
+        var serviceProvider = services.BuildServiceProvider();
+
+        var functionContext = new Mock<FunctionContext>();
+        functionContext.SetupProperty(context => context.InstanceServices, serviceProvider);
+
+        var responseHeaders = new HttpHeadersCollection();
+        var responseBody = new MemoryStream();
+        var response = new Mock<HttpResponseData>(functionContext.Object);
+        response.SetupProperty(httpResponse => httpResponse.StatusCode);
+        response.SetupProperty(httpResponse => httpResponse.Body, responseBody);
+        response.SetupGet(httpResponse => httpResponse.Headers).Returns(responseHeaders);
+        response.SetupGet(httpResponse => httpResponse.Cookies).Returns(Mock.Of<HttpCookies>());
+
+        var request = new Mock<HttpRequestData>(functionContext.Object);
+        request.Setup(httpRequest => httpRequest.CreateResponse()).Returns(response.Object);
+        request.SetupGet(httpRequest => httpRequest.Body).Returns(Stream.Null);
+        request.SetupGet(httpRequest => httpRequest.Headers).Returns(new HttpHeadersCollection());
+        request.SetupGet(httpRequest => httpRequest.Identities).Returns(Array.Empty<ClaimsIdentity>());
+        request.SetupGet(httpRequest => httpRequest.Method).Returns("GET");
+        request.SetupGet(httpRequest => httpRequest.Url).Returns(new Uri("https://localhost/api/stations/station-001/availability"));
+
+        var blobStorage = new Mock<IBikeDataBlobStorage>();
+        blobStorage
+            .Setup(storage => storage.GetAvailabilityProfileAsync("station-001", cancellationToken))
+            .ReturnsAsync([
+                new HourlyAvailability
+                {
+                    Hour = 10,
+                    AverageBikesAvailable = 7.5
+                },
+                new HourlyAvailability
+                {
+                    Hour = 11,
+                    AverageBikesAvailable = 5.25
+                }
+            ]);
+
+        var function = new StationsFunctions(new AggregatedBikeDataService(blobStorage.Object), NullLogger<StationsFunctions>.Instance);
+
+        var responseData = await function.GetStationAvailability(request.Object, "station-001", cancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, responseData.StatusCode);
+        Assert.True(responseData.Headers.TryGetValues("Access-Control-Allow-Origin", out var origins));
+        Assert.Contains("https://kuoste.github.io", origins);
+
+        responseData.Body.Position = 0;
+        using var reader = new StreamReader(responseData.Body);
+        Assert.Equal("[{\"hour\":10,\"averageBikesAvailable\":7.5},{\"hour\":11,\"averageBikesAvailable\":5.25}]", await reader.ReadToEndAsync(cancellationToken));
+    }
+
+    [Fact]
     public async Task GetStationDestinations_ReturnsOkResponseWithStoredDestinations()
     {
         var cancellationToken = TestContext.Current.CancellationToken;

--- a/tests/HslBikeDataAggregator.Tests/Services/AggregatedBikeDataServiceTests.cs
+++ b/tests/HslBikeDataAggregator.Tests/Services/AggregatedBikeDataServiceTests.cs
@@ -94,13 +94,26 @@ public sealed class AggregatedBikeDataServiceTests
     }
 
     [Fact]
-    public async Task GetAvailabilityAsync_ReturnsEmptyCollection()
+    public async Task GetAvailabilityAsync_ReturnsAvailabilityProfileFromBlobStorage()
     {
-        var service = new AggregatedBikeDataService(Mock.Of<IBikeDataBlobStorage>());
+        var blobStorage = new Mock<IBikeDataBlobStorage>();
+        blobStorage
+            .Setup(storage => storage.GetAvailabilityProfileAsync("station-001", CancellationToken))
+            .ReturnsAsync([
+                new HourlyAvailability
+                {
+                    Hour = 10,
+                    AverageBikesAvailable = 7.5
+                }
+            ]);
+
+        var service = new AggregatedBikeDataService(blobStorage.Object);
 
         var result = await service.GetAvailabilityAsync("station-001", CancellationToken);
 
-        Assert.Empty(result);
+        var availability = Assert.Single(result);
+        Assert.Equal(10, availability.Hour);
+        Assert.Equal(7.5, availability.AverageBikesAvailable);
     }
 
     [Fact]

--- a/tests/HslBikeDataAggregator.Tests/Services/AvailabilityProfileServiceTests.cs
+++ b/tests/HslBikeDataAggregator.Tests/Services/AvailabilityProfileServiceTests.cs
@@ -1,0 +1,73 @@
+using HslBikeDataAggregator.Models;
+using HslBikeDataAggregator.Services;
+
+namespace HslBikeDataAggregator.Tests.Services;
+
+public sealed class AvailabilityProfileServiceTests
+{
+    [Fact]
+    public void BuildProfiles_GroupsSnapshotsByStationAndHour()
+    {
+        var snapshots = new[]
+        {
+            new StationSnapshot
+            {
+                Timestamp = new DateTimeOffset(2026, 4, 4, 10, 5, 0, TimeSpan.Zero),
+                BikeCounts = new Dictionary<string, int>
+                {
+                    ["station-001"] = 7,
+                    ["station-002"] = 3
+                }
+            },
+            new StationSnapshot
+            {
+                Timestamp = new DateTimeOffset(2026, 4, 4, 10, 35, 0, TimeSpan.Zero),
+                BikeCounts = new Dictionary<string, int>
+                {
+                    ["station-001"] = 9
+                }
+            },
+            new StationSnapshot
+            {
+                Timestamp = new DateTimeOffset(2026, 4, 4, 11, 5, 0, TimeSpan.Zero),
+                BikeCounts = new Dictionary<string, int>
+                {
+                    ["station-001"] = 5,
+                    ["station-002"] = 4
+                }
+            }
+        };
+
+        var service = new AvailabilityProfileService();
+
+        var profiles = service.BuildProfiles(snapshots);
+
+        var station001Profile = Assert.IsAssignableFrom<IReadOnlyList<HourlyAvailability>>(profiles["station-001"]);
+        Assert.Collection(
+            station001Profile,
+            availability =>
+            {
+                Assert.Equal(10, availability.Hour);
+                Assert.Equal(8, availability.AverageBikesAvailable);
+            },
+            availability =>
+            {
+                Assert.Equal(11, availability.Hour);
+                Assert.Equal(5, availability.AverageBikesAvailable);
+            });
+
+        var station002Profile = Assert.IsAssignableFrom<IReadOnlyList<HourlyAvailability>>(profiles["station-002"]);
+        Assert.Collection(
+            station002Profile,
+            availability =>
+            {
+                Assert.Equal(10, availability.Hour);
+                Assert.Equal(3, availability.AverageBikesAvailable);
+            },
+            availability =>
+            {
+                Assert.Equal(11, availability.Hour);
+                Assert.Equal(4, availability.AverageBikesAvailable);
+            });
+    }
+}

--- a/tests/HslBikeDataAggregator.Tests/Services/PollStationsServiceTests.cs
+++ b/tests/HslBikeDataAggregator.Tests/Services/PollStationsServiceTests.cs
@@ -95,10 +95,18 @@ public sealed class PollStationsServiceTests
             .Callback<IReadOnlyList<StationSnapshot>, CancellationToken>((snapshots, _) => writtenSnapshots = snapshots)
             .Returns(Task.CompletedTask);
 
+        var writtenAvailabilityProfiles = new Dictionary<string, IReadOnlyList<HourlyAvailability>>(StringComparer.Ordinal);
+        blobStorage
+            .Setup(storage => storage.WriteAvailabilityProfileAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<HourlyAvailability>>(), It.IsAny<CancellationToken>()))
+            .Callback<string, IReadOnlyList<HourlyAvailability>, CancellationToken>((stationId, availabilityProfile, _) => writtenAvailabilityProfiles[stationId] = availabilityProfile)
+            .Returns(Task.CompletedTask);
+
         var timestamp = new DateTimeOffset(2026, 4, 3, 10, 10, 0, TimeSpan.Zero);
+        var availabilityProfileService = new AvailabilityProfileService();
         var service = new PollStationsService(
             digitransitStationClient,
             blobStorage.Object,
+            availabilityProfileService,
             options,
             new FixedTimeProvider(timestamp),
             NullLogger<PollStationsService>.Instance);
@@ -123,6 +131,11 @@ public sealed class PollStationsServiceTests
         Assert.Equal(new DateTimeOffset(2026, 4, 3, 10, 5, 0, TimeSpan.Zero), writtenSnapshots[0].Timestamp);
         Assert.Equal(timestamp, writtenSnapshots[1].Timestamp);
         Assert.Equal(9, writtenSnapshots[1].BikeCounts["001"]);
+
+        var station001Profile = Assert.IsAssignableFrom<IReadOnlyList<HourlyAvailability>>(writtenAvailabilityProfiles["001"]);
+        var station001Availability = Assert.Single(station001Profile);
+        Assert.Equal(10, station001Availability.Hour);
+        Assert.Equal(9, station001Availability.AverageBikesAvailable);
 
         Assert.Equal(timestamp, result.Timestamp);
         Assert.Equal(1, result.StationCount);


### PR DESCRIPTION
## Summary
- store hourly availability profiles in blob storage alongside polled station snapshots
- serve stored availability profiles from `GET /api/stations/{id}/availability`
- add automated tests for hourly profile aggregation, polling persistence, and the availability endpoint

## Validation
- `dotnet build HslBikeDataAggregator.slnx`
- `HslBikeDataAggregator.Tests.Services.AvailabilityProfileServiceTests`
- `HslBikeDataAggregator.Tests.Services.PollStationsServiceTests`
- `HslBikeDataAggregator.Tests.Services.AggregatedBikeDataServiceTests`
- `HslBikeDataAggregator.Tests.Functions.StationsFunctionsTests`

Closes #6