### PR TITLE
Reduce storage costs with live station caching and Flex dev deployment

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -22,7 +22,7 @@ jobs:
     env:
       AZURE_LOCATION: ${{ vars.AZURE_LOCATION }}
       AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP || 'rg-hsl-bike-data-aggregator-dev' }}
-      AZURE_FUNCTION_APP_NAME: ${{ vars.AZURE_FUNCTION_APP_NAME || 'func-hsl-bike-data-aggregator-dev' }}
+      AZURE_FUNCTION_APP_NAME: ${{ vars.AZURE_FUNCTION_APP_NAME || 'func-hsl-bike-data-aggregator-dev-flex' }}
 
     steps:
       - name: Check out repository
@@ -44,6 +44,9 @@ jobs:
 
       - name: Publish Function App
         run: dotnet publish src/HslBikeDataAggregator/HslBikeDataAggregator.csproj --configuration Release --output ./artifacts/publish
+
+      - name: Create deployment package
+        run: cd artifacts/publish && zip -r ../released-package.zip .
 
       - name: Sign in to Azure
         uses: azure/login@v2
@@ -92,5 +95,6 @@ jobs:
       - name: Deploy Function App package
         uses: Azure/functions-action@v1
         with:
-          app-name: ${{ vars.AZURE_FUNCTION_APP_NAME }}
-          package: ./artifacts/publish
+          app-name: ${{ env.AZURE_FUNCTION_APP_NAME }}
+          package: ./artifacts/released-package.zip
+          sku: flexconsumption

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -25,7 +25,7 @@ jobs:
     env:
       AZURE_LOCATION: ${{ vars.AZURE_LOCATION }}
       AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP || 'rg-hsl-bike-data-aggregator-prod' }}
-      AZURE_FUNCTION_APP_NAME: ${{ vars.AZURE_FUNCTION_APP_NAME || 'func-hsl-bike-data-aggregator-prod' }}
+      AZURE_FUNCTION_APP_NAME: ${{ vars.AZURE_FUNCTION_APP_NAME || 'func-hsl-bike-data-aggregator-prod-flex' }}
 
     steps:
       - name: Check out repository
@@ -49,6 +49,9 @@ jobs:
 
       - name: Publish Function App
         run: dotnet publish src/HslBikeDataAggregator/HslBikeDataAggregator.csproj --configuration Release --output ./artifacts/publish
+
+      - name: Create deployment package
+        run: cd artifacts/publish && zip -r ../released-package.zip .
 
       - name: Sign in to Azure
         uses: azure/login@v2
@@ -97,5 +100,6 @@ jobs:
       - name: Deploy Function App package
         uses: Azure/functions-action@v1
         with:
-          app-name: ${{ vars.AZURE_FUNCTION_APP_NAME }}
-          package: ./artifacts/publish
+          app-name: ${{ env.AZURE_FUNCTION_APP_NAME }}
+          package: ./artifacts/released-package.zip
+          sku: flexconsumption

--- a/infra/dev.bicepparam
+++ b/infra/dev.bicepparam
@@ -1,8 +1,8 @@
 using './main.bicep'
 
 param environmentName = 'dev'
-param functionAppName = 'func-hsl-bike-data-aggregator-dev'
+param functionAppName = 'func-hsl-bike-data-aggregator-dev-flex'
 param corsAllowedOrigin = 'https://kuoste.github.io'
-param pollIntervalCron = '0 */5 * * * *'
+param pollIntervalCron = '0 */15 * * * *'
 param snapshotHistoryLimit = 60
 param historyProcessingCron = '0 0 2 * * *'

--- a/infra/dev.json
+++ b/infra/dev.json
@@ -6,13 +6,13 @@
       "value": "dev"
     },
     "functionAppName": {
-      "value": "func-hsl-bike-data-aggregator-dev"
+      "value": "func-hsl-bike-data-aggregator-dev-flex"
     },
     "corsAllowedOrigin": {
       "value": "https://kuoste.github.io"
     },
     "pollIntervalCron": {
-      "value": "0 */5 * * * *"
+      "value": "0 */15 * * * *"
     },
     "snapshotHistoryLimit": {
       "value": 60

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -18,7 +18,7 @@ param functionAppName string
 param corsAllowedOrigin string = 'https://kuoste.github.io'
 
 @description('Cron expression used by the PollStations timer trigger.')
-param pollIntervalCron string = '0 */5 * * * *'
+param pollIntervalCron string = '0 */15 * * * *'
 
 @description('Number of snapshots retained in blob storage.')
 @minValue(1)
@@ -30,7 +30,8 @@ param historyProcessingCron string = '0 0 2 * * *'
 var appServicePlanName = '${functionAppName}-plan'
 var applicationInsightsName = '${functionAppName}-appi'
 var storageAccountName = take('st${toLower(replace(replace(functionAppName, '-', ''), '_', ''))}${uniqueString(resourceGroup().id)}', 24)
-var contentShareName = take(toLower('${replace(replace(functionAppName, '-', ''), '_', '')}${uniqueString(functionAppName)}'), 63)
+var deploymentStorageContainerName = 'deployment-packages'
+var deploymentStorageContainerUrl = 'https://${storageAccount.name}.blob.${environment().suffixes.storage}/${deploymentStorageContainerName}'
 var storageConnectionString = 'DefaultEndpointsProtocol=https;AccountName=${storageAccount.name};EndpointSuffix=${environment().suffixes.storage};AccountKey=${storageAccount.listKeys().keys[0].value}'
 
 resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
@@ -70,16 +71,29 @@ resource applicationInsights 'Microsoft.Insights/components@2020-02-02' = {
   }
 }
 
-resource appServicePlan 'Microsoft.Web/serverfarms@2023-12-01' = {
+resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2023-05-01' = {
+  name: 'default'
+  parent: storageAccount
+}
+
+resource deploymentStorageContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' = {
+  name: deploymentStorageContainerName
+  parent: blobService
+  properties: {
+    publicAccess: 'None'
+  }
+}
+
+resource appServicePlan 'Microsoft.Web/serverfarms@2024-04-01' = {
   name: appServicePlanName
   location: location
   kind: 'functionapp'
   sku: {
-    name: 'Y1'
-    tier: 'Dynamic'
+    name: 'FC1'
+    tier: 'FlexConsumption'
   }
   properties: {
-    reserved: false
+    reserved: true
   }
   tags: {
     'azd-env-name': environmentName
@@ -88,10 +102,10 @@ resource appServicePlan 'Microsoft.Web/serverfarms@2023-12-01' = {
   }
 }
 
-resource functionApp 'Microsoft.Web/sites@2023-12-01' = {
+resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
   name: functionAppName
   location: location
-  kind: 'functionapp'
+  kind: 'functionapp,linux'
   identity: {
     type: 'SystemAssigned'
   }
@@ -99,6 +113,25 @@ resource functionApp 'Microsoft.Web/sites@2023-12-01' = {
     serverFarmId: appServicePlan.id
     httpsOnly: true
     clientAffinityEnabled: false
+    functionAppConfig: {
+      deployment: {
+        storage: {
+          type: 'blobContainer'
+          value: deploymentStorageContainerUrl
+          authentication: {
+            type: 'StorageAccountConnectionString'
+            storageAccountConnectionStringName: 'AzureWebJobsStorage'
+          }
+        }
+      }
+      runtime: {
+        name: 'dotnet-isolated'
+        version: '10.0'
+      }
+      scaleAndConcurrency: {
+        instanceMemoryMB: 512
+      }
+    }
     siteConfig: {
       alwaysOn: false
       appSettings: [
@@ -129,18 +162,6 @@ resource functionApp 'Microsoft.Web/sites@2023-12-01' = {
         {
           name: 'HistoryProcessingCron'
           value: historyProcessingCron
-        }
-        {
-          name: 'WEBSITE_CONTENTAZUREFILECONNECTIONSTRING'
-          value: storageConnectionString
-        }
-        {
-          name: 'WEBSITE_CONTENTSHARE'
-          value: contentShareName
-        }
-        {
-          name: 'WEBSITE_RUN_FROM_PACKAGE'
-          value: '1'
         }
       ]
       cors: {

--- a/infra/prod.bicepparam
+++ b/infra/prod.bicepparam
@@ -1,8 +1,8 @@
 using './main.bicep'
 
 param environmentName = 'prod'
-param functionAppName = 'func-hsl-bike-data-aggregator-prod'
+param functionAppName = 'func-hsl-bike-data-aggregator-prod-flex'
 param corsAllowedOrigin = 'https://kuoste.github.io'
-param pollIntervalCron = '0 */5 * * * *'
+param pollIntervalCron = '0 */15 * * * *'
 param snapshotHistoryLimit = 60
 param historyProcessingCron = '0 0 2 * * *'

--- a/infra/prod.json
+++ b/infra/prod.json
@@ -6,13 +6,13 @@
       "value": "prod"
     },
     "functionAppName": {
-      "value": "func-hsl-bike-data-aggregator-prod"
+      "value": "func-hsl-bike-data-aggregator-prod-flex"
     },
     "corsAllowedOrigin": {
       "value": "https://kuoste.github.io"
     },
     "pollIntervalCron": {
-      "value": "0 */5 * * * *"
+      "value": "0 */15 * * * *"
     },
     "snapshotHistoryLimit": {
       "value": 60

--- a/src/HslBikeDataAggregator/Functions/StationsFunctions.cs
+++ b/src/HslBikeDataAggregator/Functions/StationsFunctions.cs
@@ -14,41 +14,46 @@ public sealed class StationsFunctions(
     ILogger<StationsFunctions> logger)
 {
     private const string AllowedOrigin = "https://kuoste.github.io";
+    private const string LiveStationsCacheControl = "public, max-age=120";
+    private const string SnapshotsCacheControl = "public, max-age=900";
+    private const string StationStatisticsCacheControl = "public, max-age=3600";
 
     [Function(nameof(GetStations))]
     public Task<HttpResponseData> GetStations(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "stations")] HttpRequestData request,
         CancellationToken cancellationToken)
-        => CreateJsonResponseAsync(request, bikeDataService.GetStationsAsync(cancellationToken), cancellationToken);
+        => CreateJsonResponseAsync(request, bikeDataService.GetStationsAsync(cancellationToken), LiveStationsCacheControl, cancellationToken);
 
     [Function(nameof(GetSnapshots))]
     public Task<HttpResponseData> GetSnapshots(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "snapshots")] HttpRequestData request,
         CancellationToken cancellationToken)
-        => CreateJsonResponseAsync(request, bikeDataService.GetSnapshotsAsync(cancellationToken), cancellationToken);
+        => CreateJsonResponseAsync(request, bikeDataService.GetSnapshotsAsync(cancellationToken), SnapshotsCacheControl, cancellationToken);
 
     [Function(nameof(GetStationAvailability))]
     public Task<HttpResponseData> GetStationAvailability(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "stations/{stationId}/availability")] HttpRequestData request,
         string stationId,
         CancellationToken cancellationToken)
-        => CreateJsonResponseAsync(request, bikeDataService.GetAvailabilityAsync(stationId, cancellationToken), cancellationToken);
+        => CreateJsonResponseAsync(request, bikeDataService.GetAvailabilityAsync(stationId, cancellationToken), StationStatisticsCacheControl, cancellationToken);
 
     [Function(nameof(GetStationDestinations))]
     public Task<HttpResponseData> GetStationDestinations(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "stations/{stationId}/destinations")] HttpRequestData request,
         string stationId,
         CancellationToken cancellationToken)
-        => CreateJsonResponseAsync(request, bikeDataService.GetDestinationsAsync(stationId, cancellationToken), cancellationToken);
+        => CreateJsonResponseAsync(request, bikeDataService.GetDestinationsAsync(stationId, cancellationToken), StationStatisticsCacheControl, cancellationToken);
 
     private async Task<HttpResponseData> CreateJsonResponseAsync<T>(
         HttpRequestData request,
         Task<IReadOnlyList<T>> payloadTask,
+        string cacheControl,
         CancellationToken cancellationToken)
     {
         var payload = await payloadTask;
         var response = request.CreateResponse(HttpStatusCode.OK);
         response.Headers.Add("Access-Control-Allow-Origin", AllowedOrigin);
+        response.Headers.Add("Cache-Control", cacheControl);
         response.Headers.Add("Vary", "Origin");
         await response.WriteAsJsonAsync(payload, cancellationToken);
         logger.LogInformation("Served {PayloadType} response with {Count} items.", typeof(T).Name, payload.Count);

--- a/src/HslBikeDataAggregator/Program.cs
+++ b/src/HslBikeDataAggregator/Program.cs
@@ -38,6 +38,7 @@ builder.Services.AddHttpClient<DigitransitStationClient>();
 builder.Services.AddHttpClient<ProcessStationHistoryService>();
 builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddSingleton<AvailabilityProfileService>();
+builder.Services.AddSingleton<LiveStationCacheService>();
 builder.Services.AddSingleton(provider =>
 {
     var configuration = provider.GetRequiredService<IConfiguration>();

--- a/src/HslBikeDataAggregator/Services/AggregatedBikeDataService.cs
+++ b/src/HslBikeDataAggregator/Services/AggregatedBikeDataService.cs
@@ -4,10 +4,12 @@ using HslBikeDataAggregator.Models;
 
 namespace HslBikeDataAggregator.Services;
 
-public sealed class AggregatedBikeDataService(IBikeDataBlobStorage bikeDataBlobStorage)
+public sealed class AggregatedBikeDataService(
+    IBikeDataBlobStorage bikeDataBlobStorage,
+    LiveStationCacheService liveStationCacheService)
 {
     public Task<IReadOnlyList<BikeStation>> GetStationsAsync(CancellationToken cancellationToken)
-        => bikeDataBlobStorage.GetLatestStationsAsync(cancellationToken);
+        => liveStationCacheService.GetStationsAsync(cancellationToken);
 
     public Task<IReadOnlyList<StationSnapshot>> GetSnapshotsAsync(CancellationToken cancellationToken)
         => bikeDataBlobStorage.GetRecentSnapshotsAsync(cancellationToken);

--- a/src/HslBikeDataAggregator/Services/LiveStationCacheService.cs
+++ b/src/HslBikeDataAggregator/Services/LiveStationCacheService.cs
@@ -1,0 +1,60 @@
+using HslBikeDataAggregator.Models;
+
+using Microsoft.Extensions.Logging;
+
+namespace HslBikeDataAggregator.Services;
+
+public sealed class LiveStationCacheService(
+    DigitransitStationClient digitransitStationClient,
+    TimeProvider timeProvider,
+    ILogger<LiveStationCacheService> logger)
+{
+    private static readonly TimeSpan CacheLifetime = TimeSpan.FromMinutes(2);
+
+    private readonly SemaphoreSlim refreshLock = new(1, 1);
+    private CachedStations? cachedStations;
+
+    public async Task<IReadOnlyList<BikeStation>> GetStationsAsync(CancellationToken cancellationToken)
+    {
+        var currentTime = timeProvider.GetUtcNow();
+        if (TryGetCachedStations(currentTime, out var stations))
+        {
+            logger.LogDebug("Returning {StationCount} cached live stations.", stations.Count);
+            return stations;
+        }
+
+        await refreshLock.WaitAsync(cancellationToken);
+        try
+        {
+            currentTime = timeProvider.GetUtcNow();
+            if (TryGetCachedStations(currentTime, out stations))
+            {
+                logger.LogDebug("Returning {StationCount} cached live stations after waiting for a refresh.", stations.Count);
+                return stations;
+            }
+
+            stations = await digitransitStationClient.FetchStationsAsync(cancellationToken);
+            cachedStations = new CachedStations(stations, currentTime + CacheLifetime);
+            logger.LogInformation("Fetched {StationCount} live stations from Digitransit and cached them until {ExpiresAt}.", stations.Count, cachedStations.ExpiresAt);
+            return stations;
+        }
+        finally
+        {
+            refreshLock.Release();
+        }
+    }
+
+    private bool TryGetCachedStations(DateTimeOffset currentTime, out IReadOnlyList<BikeStation> stations)
+    {
+        if (cachedStations is not null && cachedStations.ExpiresAt >= currentTime)
+        {
+            stations = cachedStations.Stations;
+            return true;
+        }
+
+        stations = [];
+        return false;
+    }
+
+    private sealed record CachedStations(IReadOnlyList<BikeStation> Stations, DateTimeOffset ExpiresAt);
+}

--- a/src/HslBikeDataAggregator/Services/PollStationsService.cs
+++ b/src/HslBikeDataAggregator/Services/PollStationsService.cs
@@ -34,7 +34,6 @@ public sealed class PollStationsService(
             .ToArray();
         var availabilityProfiles = availabilityProfileService.BuildProfiles(updatedSnapshots);
 
-        await bikeDataBlobStorage.WriteLatestStationsAsync(stations, cancellationToken);
         await bikeDataBlobStorage.WriteRecentSnapshotsAsync(updatedSnapshots, cancellationToken);
         foreach (var availabilityProfile in availabilityProfiles)
         {
@@ -42,7 +41,7 @@ public sealed class PollStationsService(
         }
 
         logger.LogInformation(
-            "Stored {StationCount} stations, {SnapshotCount} snapshots, and {AvailabilityProfileCount} hourly availability profiles at {Timestamp}.",
+            "Processed {StationCount} stations and stored {SnapshotCount} snapshots plus {AvailabilityProfileCount} hourly availability profiles at {Timestamp}.",
             stations.Count,
             updatedSnapshots.Length,
             availabilityProfiles.Count,

--- a/src/HslBikeDataAggregator/Storage/BikeDataBlobNames.cs
+++ b/src/HslBikeDataAggregator/Storage/BikeDataBlobNames.cs
@@ -3,7 +3,6 @@ namespace HslBikeDataAggregator.Storage;
 public static class BikeDataBlobNames
 {
     public const string ContainerName = "bike-data";
-    public const string LatestStations = "stations/latest.json";
     public const string RecentSnapshots = "snapshots/recent.json";
 
     public static string AvailabilityProfile(string stationId) => $"availability/{stationId}.json";

--- a/src/HslBikeDataAggregator/Storage/BikeDataBlobStorage.cs
+++ b/src/HslBikeDataAggregator/Storage/BikeDataBlobStorage.cs
@@ -11,9 +11,6 @@ public sealed class BikeDataBlobStorage(BlobContainerClient blobContainerClient)
 {
     private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web);
 
-    public Task<IReadOnlyList<BikeStation>> GetLatestStationsAsync(CancellationToken cancellationToken)
-        => ReadBlobAsync<BikeStation>(BikeDataBlobNames.LatestStations, cancellationToken);
-
     public async Task<IReadOnlyList<StationSnapshot>> GetRecentSnapshotsAsync(CancellationToken cancellationToken)
         => await ReadBlobAsync<StationSnapshot>(BikeDataBlobNames.RecentSnapshots, cancellationToken);
 
@@ -68,16 +65,6 @@ public sealed class BikeDataBlobStorage(BlobContainerClient blobContainerClient)
         {
             return [];
         }
-    }
-
-    public async Task WriteLatestStationsAsync(IReadOnlyList<BikeStation> stations, CancellationToken cancellationToken)
-    {
-        ArgumentNullException.ThrowIfNull(stations);
-
-        await blobContainerClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
-        await blobContainerClient
-            .GetBlobClient(BikeDataBlobNames.LatestStations)
-            .UploadAsync(BinaryData.FromObjectAsJson(stations, SerializerOptions), overwrite: true, cancellationToken);
     }
 
     public async Task WriteRecentSnapshotsAsync(IReadOnlyList<StationSnapshot> snapshots, CancellationToken cancellationToken)

--- a/src/HslBikeDataAggregator/Storage/IBikeDataBlobStorage.cs
+++ b/src/HslBikeDataAggregator/Storage/IBikeDataBlobStorage.cs
@@ -4,8 +4,6 @@ namespace HslBikeDataAggregator.Storage;
 
 public interface IBikeDataBlobStorage
 {
-    Task<IReadOnlyList<BikeStation>> GetLatestStationsAsync(CancellationToken cancellationToken);
-
     Task<IReadOnlyList<StationSnapshot>> GetRecentSnapshotsAsync(CancellationToken cancellationToken);
 
     Task<IReadOnlyList<HourlyAvailability>> GetAvailabilityProfileAsync(string stationId, CancellationToken cancellationToken);
@@ -13,8 +11,6 @@ public interface IBikeDataBlobStorage
     Task<IReadOnlyList<StationHistory>> GetStationDestinationsAsync(string stationId, CancellationToken cancellationToken);
 
     Task<IReadOnlyList<string>> ListStationDestinationIdsAsync(CancellationToken cancellationToken);
-
-    Task WriteLatestStationsAsync(IReadOnlyList<BikeStation> stations, CancellationToken cancellationToken);
 
     Task WriteRecentSnapshotsAsync(IReadOnlyList<StationSnapshot> snapshots, CancellationToken cancellationToken);
 

--- a/src/HslBikeDataAggregator/local.settings.example.json
+++ b/src/HslBikeDataAggregator/local.settings.example.json
@@ -4,7 +4,7 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
     "DigitransitSubscriptionKey": "",
-    "PollIntervalCron": "0 */5 * * * *",
+    "PollIntervalCron": "0 */15 * * * *",
     "SnapshotHistoryLimit": "60"
   },
   "Host": {

--- a/tests/HslBikeDataAggregator.Tests/Configuration/DeploymentWorkflowConfigurationTests.cs
+++ b/tests/HslBikeDataAggregator.Tests/Configuration/DeploymentWorkflowConfigurationTests.cs
@@ -53,9 +53,9 @@ public sealed class DeploymentWorkflowConfigurationTests
         var prodYaml = await File.ReadAllTextAsync(GetRepositoryFilePath(".github", "workflows", "deploy-prod.yml"), cancellationToken);
 
         Assert.Contains("rg-hsl-bike-data-aggregator-dev", devYaml, StringComparison.Ordinal);
-        Assert.Contains("func-hsl-bike-data-aggregator-dev", devYaml, StringComparison.Ordinal);
+        Assert.Contains("func-hsl-bike-data-aggregator-dev-flex", devYaml, StringComparison.Ordinal);
         Assert.Contains("rg-hsl-bike-data-aggregator-prod", prodYaml, StringComparison.Ordinal);
-        Assert.Contains("func-hsl-bike-data-aggregator-prod", prodYaml, StringComparison.Ordinal);
+        Assert.Contains("func-hsl-bike-data-aggregator-prod-flex", prodYaml, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -78,8 +78,8 @@ public sealed class DeploymentWorkflowConfigurationTests
         var devParameters = await File.ReadAllTextAsync(GetRepositoryFilePath("infra", "dev.bicepparam"), cancellationToken);
         var prodParameters = await File.ReadAllTextAsync(GetRepositoryFilePath("infra", "prod.bicepparam"), cancellationToken);
 
-        Assert.Contains("func-hsl-bike-data-aggregator-dev", devParameters, StringComparison.Ordinal);
-        Assert.Contains("func-hsl-bike-data-aggregator-prod", prodParameters, StringComparison.Ordinal);
+        Assert.Contains("func-hsl-bike-data-aggregator-dev-flex", devParameters, StringComparison.Ordinal);
+        Assert.Contains("func-hsl-bike-data-aggregator-prod-flex", prodParameters, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -98,6 +98,52 @@ public sealed class DeploymentWorkflowConfigurationTests
         Assert.Contains("\"historyProcessingCron\"", prodJson, StringComparison.Ordinal);
         Assert.Contains("param historyProcessingCron = '0 0 2 * * *'", devBicepParameters, StringComparison.Ordinal);
         Assert.Contains("param historyProcessingCron = '0 0 2 * * *'", prodBicepParameters, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task InfrastructureParameters_ContainReducedPollIntervalDefaults()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var mainBicep = await File.ReadAllTextAsync(GetRepositoryFilePath("infra", "main.bicep"), cancellationToken);
+        var devJson = await File.ReadAllTextAsync(GetRepositoryFilePath("infra", "dev.json"), cancellationToken);
+        var prodJson = await File.ReadAllTextAsync(GetRepositoryFilePath("infra", "prod.json"), cancellationToken);
+        var devBicepParameters = await File.ReadAllTextAsync(GetRepositoryFilePath("infra", "dev.bicepparam"), cancellationToken);
+        var prodBicepParameters = await File.ReadAllTextAsync(GetRepositoryFilePath("infra", "prod.bicepparam"), cancellationToken);
+
+        Assert.Contains("param pollIntervalCron string = '0 */15 * * * *'", mainBicep, StringComparison.Ordinal);
+        Assert.Contains("\"pollIntervalCron\"", devJson, StringComparison.Ordinal);
+        Assert.Contains("\"pollIntervalCron\"", prodJson, StringComparison.Ordinal);
+        Assert.Contains("\"0 */15 * * * *\"", devJson, StringComparison.Ordinal);
+        Assert.Contains("\"0 */15 * * * *\"", prodJson, StringComparison.Ordinal);
+        Assert.Contains("param pollIntervalCron = '0 */15 * * * *'", devBicepParameters, StringComparison.Ordinal);
+        Assert.Contains("param pollIntervalCron = '0 */15 * * * *'", prodBicepParameters, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Infrastructure_UsesFlexConsumptionPlan()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var mainBicep = await File.ReadAllTextAsync(GetRepositoryFilePath("infra", "main.bicep"), cancellationToken);
+
+        Assert.Contains("tier: 'FlexConsumption'", mainBicep, StringComparison.Ordinal);
+        Assert.Contains("name: 'FC1'", mainBicep, StringComparison.Ordinal);
+        Assert.Contains("kind: 'functionapp,linux'", mainBicep, StringComparison.Ordinal);
+        Assert.Contains("functionAppConfig:", mainBicep, StringComparison.Ordinal);
+        Assert.Contains("deploymentStorageContainerName = 'deployment-packages'", mainBicep, StringComparison.Ordinal);
+        Assert.DoesNotContain("WEBSITE_CONTENTSHARE", mainBicep, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task DeployWorkflows_PublishFlexConsumptionPackages()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var devYaml = await File.ReadAllTextAsync(GetRepositoryFilePath(".github", "workflows", "deploy-dev.yml"), cancellationToken);
+        var prodYaml = await File.ReadAllTextAsync(GetRepositoryFilePath(".github", "workflows", "deploy-prod.yml"), cancellationToken);
+
+        Assert.Contains("released-package.zip", devYaml, StringComparison.Ordinal);
+        Assert.Contains("sku: flexconsumption", devYaml, StringComparison.Ordinal);
+        Assert.Contains("released-package.zip", prodYaml, StringComparison.Ordinal);
+        Assert.Contains("sku: flexconsumption", prodYaml, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/HslBikeDataAggregator.Tests/Configuration/ScaffoldConfigurationTests.cs
+++ b/tests/HslBikeDataAggregator.Tests/Configuration/ScaffoldConfigurationTests.cs
@@ -34,6 +34,21 @@ public sealed class ScaffoldConfigurationTests
         Assert.Equal("https://kuoste.github.io", corsOrigin);
     }
 
+    [Fact]
+    public async Task LocalSettingsTemplate_ContainsReducedPollIntervalDefault()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var json = await File.ReadAllTextAsync(GetRepositoryFilePath("src", "HslBikeDataAggregator", "local.settings.example.json"), cancellationToken);
+        using var document = JsonDocument.Parse(json);
+
+        var pollIntervalCron = document.RootElement
+            .GetProperty("Values")
+            .GetProperty("PollIntervalCron")
+            .GetString();
+
+        Assert.Equal("0 */15 * * * *", pollIntervalCron);
+    }
+
     private static string GetRepositoryFilePath(params string[] parts)
     {
         var repositoryRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));

--- a/tests/HslBikeDataAggregator.Tests/Functions/StationsFunctionsTests.cs
+++ b/tests/HslBikeDataAggregator.Tests/Functions/StationsFunctionsTests.cs
@@ -1,8 +1,10 @@
 using System.Net;
+using System.Text;
 using System.Security.Claims;
 
 using Azure.Core.Serialization;
 
+using HslBikeDataAggregator.Configuration;
 using HslBikeDataAggregator.Functions;
 using HslBikeDataAggregator.Models;
 using HslBikeDataAggregator.Services;
@@ -12,6 +14,7 @@ using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 
 using Moq;
 
@@ -20,7 +23,7 @@ namespace HslBikeDataAggregator.Tests.Functions;
 public sealed class StationsFunctionsTests
 {
     [Fact]
-    public async Task GetStations_ReturnsOkResponseWithCorsHeader()
+    public async Task GetStations_ReturnsOkResponseWithCorsAndCacheHeaders()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
         var services = new ServiceCollection();
@@ -50,29 +53,46 @@ public sealed class StationsFunctionsTests
         request.SetupGet(httpRequest => httpRequest.Url).Returns(new Uri("https://localhost/api/stations"));
 
         var blobStorage = new Mock<IBikeDataBlobStorage>();
-        blobStorage
-            .Setup(storage => storage.GetLatestStationsAsync(cancellationToken))
-            .ReturnsAsync([
-                new BikeStation
-                {
-                    Id = "station-001",
-                    Name = "Central Station",
-                    Lat = 60.1708,
-                    Lon = 24.941,
-                    Capacity = 24,
-                    BikesAvailable = 8,
-                    SpacesAvailable = 16,
-                    IsActive = true
-                }
-            ]);
 
-        var function = new StationsFunctions(new AggregatedBikeDataService(blobStorage.Object), NullLogger<StationsFunctions>.Instance);
+        var function = new StationsFunctions(
+            CreateBikeDataService(
+                blobStorage,
+                """
+                {
+                  "data": {
+                    "vehicleRentalStations": [
+                      {
+                        "stationId": "station-001",
+                        "name": "Central Station",
+                        "lat": 60.1708,
+                        "lon": 24.941,
+                        "allowPickup": true,
+                        "allowDropoff": true,
+                        "capacity": 24,
+                        "availableVehicles": {
+                          "byType": [
+                            { "count": 8 }
+                          ]
+                        },
+                        "availableSpaces": {
+                          "byType": [
+                            { "count": 16 }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+                """),
+            NullLogger<StationsFunctions>.Instance);
 
         var responseData = await function.GetStations(request.Object, cancellationToken);
 
         Assert.Equal(HttpStatusCode.OK, responseData.StatusCode);
         Assert.True(responseData.Headers.TryGetValues("Access-Control-Allow-Origin", out var origins));
         Assert.Contains("https://kuoste.github.io", origins);
+        Assert.True(responseData.Headers.TryGetValues("Cache-Control", out var cacheControl));
+        Assert.Contains("public, max-age=120", cacheControl);
 
         responseData.Body.Position = 0;
         using var reader = new StreamReader(responseData.Body);
@@ -124,13 +144,15 @@ public sealed class StationsFunctionsTests
                 }
             ]);
 
-        var function = new StationsFunctions(new AggregatedBikeDataService(blobStorage.Object), NullLogger<StationsFunctions>.Instance);
+        var function = new StationsFunctions(CreateBikeDataService(blobStorage), NullLogger<StationsFunctions>.Instance);
 
         var responseData = await function.GetSnapshots(request.Object, cancellationToken);
 
         Assert.Equal(HttpStatusCode.OK, responseData.StatusCode);
         Assert.True(responseData.Headers.TryGetValues("Access-Control-Allow-Origin", out var origins));
         Assert.Contains("https://kuoste.github.io", origins);
+        Assert.True(responseData.Headers.TryGetValues("Cache-Control", out var cacheControl));
+        Assert.Contains("public, max-age=900", cacheControl);
 
         responseData.Body.Position = 0;
         using var reader = new StreamReader(responseData.Body);
@@ -183,13 +205,15 @@ public sealed class StationsFunctionsTests
                 }
             ]);
 
-        var function = new StationsFunctions(new AggregatedBikeDataService(blobStorage.Object), NullLogger<StationsFunctions>.Instance);
+        var function = new StationsFunctions(CreateBikeDataService(blobStorage), NullLogger<StationsFunctions>.Instance);
 
         var responseData = await function.GetStationAvailability(request.Object, "station-001", cancellationToken);
 
         Assert.Equal(HttpStatusCode.OK, responseData.StatusCode);
         Assert.True(responseData.Headers.TryGetValues("Access-Control-Allow-Origin", out var origins));
         Assert.Contains("https://kuoste.github.io", origins);
+        Assert.True(responseData.Headers.TryGetValues("Cache-Control", out var cacheControl));
+        Assert.Contains("public, max-age=3600", cacheControl);
 
         responseData.Body.Position = 0;
         using var reader = new StreamReader(responseData.Body);
@@ -240,16 +264,60 @@ public sealed class StationsFunctionsTests
                 }
             ]);
 
-        var function = new StationsFunctions(new AggregatedBikeDataService(blobStorage.Object), NullLogger<StationsFunctions>.Instance);
+        var function = new StationsFunctions(CreateBikeDataService(blobStorage), NullLogger<StationsFunctions>.Instance);
 
         var responseData = await function.GetStationDestinations(request.Object, "station-001", cancellationToken);
 
         Assert.Equal(HttpStatusCode.OK, responseData.StatusCode);
         Assert.True(responseData.Headers.TryGetValues("Access-Control-Allow-Origin", out var origins));
         Assert.Contains("https://kuoste.github.io", origins);
+        Assert.True(responseData.Headers.TryGetValues("Cache-Control", out var cacheControl));
+        Assert.Contains("public, max-age=3600", cacheControl);
 
         responseData.Body.Position = 0;
         using var reader = new StreamReader(responseData.Body);
         Assert.Equal("[{\"departureStationId\":\"station-001\",\"arrivalStationId\":\"station-002\",\"tripCount\":12,\"averageDurationSeconds\":425.5,\"averageDistanceMetres\":1280.2}]", await reader.ReadToEndAsync(cancellationToken));
+    }
+
+    private const string EmptyStationsResponse = """
+        {
+          "data": {
+            "vehicleRentalStations": []
+          }
+        }
+        """;
+
+    private static AggregatedBikeDataService CreateBikeDataService(Mock<IBikeDataBlobStorage> blobStorage, string liveStationsResponse = EmptyStationsResponse)
+        => new(blobStorage.Object, CreateLiveStationCacheService(liveStationsResponse));
+
+    private static LiveStationCacheService CreateLiveStationCacheService(string responseBody)
+    {
+        var handler = new StubHttpMessageHandler(_ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(responseBody, Encoding.UTF8, "application/json")
+        }));
+
+        var client = new DigitransitStationClient(
+            new HttpClient(handler),
+            Options.Create(new PollStationsOptions
+            {
+                DigitransitSubscriptionKey = "test-subscription-key"
+            }));
+
+        return new LiveStationCacheService(
+            client,
+            new FixedTimeProvider(new DateTimeOffset(2026, 4, 6, 10, 0, 0, TimeSpan.Zero)),
+            NullLogger<LiveStationCacheService>.Instance);
+    }
+
+    private sealed class StubHttpMessageHandler(Func<HttpRequestMessage, Task<HttpResponseMessage>> handler) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => handler(request);
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset timestamp) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => timestamp;
     }
 }

--- a/tests/HslBikeDataAggregator.Tests/Services/AggregatedBikeDataServiceTests.cs
+++ b/tests/HslBikeDataAggregator.Tests/Services/AggregatedBikeDataServiceTests.cs
@@ -1,6 +1,13 @@
+using System.Net;
+using System.Text;
+
+using HslBikeDataAggregator.Configuration;
 using HslBikeDataAggregator.Models;
 using HslBikeDataAggregator.Services;
 using HslBikeDataAggregator.Storage;
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 
 using Moq;
 
@@ -11,26 +18,39 @@ public sealed class AggregatedBikeDataServiceTests
     private static readonly CancellationToken CancellationToken = CancellationToken.None;
 
     [Fact]
-    public async Task GetStationsAsync_ReturnsStationsFromBlobStorage()
+    public async Task GetStationsAsync_ReturnsStationsFromLiveStationCache()
     {
         var blobStorage = new Mock<IBikeDataBlobStorage>();
-        blobStorage
-            .Setup(storage => storage.GetLatestStationsAsync(CancellationToken))
-            .ReturnsAsync([
-                new BikeStation
-                {
-                    Id = "station-001",
-                    Name = "Central Station",
-                    Lat = 60.1708,
-                    Lon = 24.941,
-                    Capacity = 24,
-                    BikesAvailable = 8,
-                    SpacesAvailable = 16,
-                    IsActive = true
-                }
-            ]);
 
-        var service = new AggregatedBikeDataService(blobStorage.Object);
+        var service = CreateService(
+            blobStorage,
+            """
+            {
+              "data": {
+                "vehicleRentalStations": [
+                  {
+                    "stationId": "station-001",
+                    "name": "Central Station",
+                    "lat": 60.1708,
+                    "lon": 24.941,
+                    "allowPickup": true,
+                    "allowDropoff": true,
+                    "capacity": 24,
+                    "availableVehicles": {
+                      "byType": [
+                        { "count": 8 }
+                      ]
+                    },
+                    "availableSpaces": {
+                      "byType": [
+                        { "count": 16 }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+            """);
 
         var result = await service.GetStationsAsync(CancellationToken);
 
@@ -39,14 +59,11 @@ public sealed class AggregatedBikeDataServiceTests
     }
 
     [Fact]
-    public async Task GetStationsAsync_ReturnsEmptyCollectionWhenBlobStorageHasNoStations()
+    public async Task GetStationsAsync_ReturnsEmptyCollectionWhenLiveStationCacheHasNoStations()
     {
         var blobStorage = new Mock<IBikeDataBlobStorage>();
-        blobStorage
-            .Setup(storage => storage.GetLatestStationsAsync(CancellationToken))
-            .ReturnsAsync([]);
 
-        var service = new AggregatedBikeDataService(blobStorage.Object);
+        var service = CreateService(blobStorage, EmptyStationsResponse);
 
         var result = await service.GetStationsAsync(CancellationToken);
 
@@ -70,7 +87,7 @@ public sealed class AggregatedBikeDataServiceTests
                 }
             ]);
 
-        var service = new AggregatedBikeDataService(blobStorage.Object);
+        var service = CreateService(blobStorage, EmptyStationsResponse);
 
         var result = await service.GetSnapshotsAsync(CancellationToken);
 
@@ -86,7 +103,7 @@ public sealed class AggregatedBikeDataServiceTests
             .Setup(storage => storage.GetRecentSnapshotsAsync(CancellationToken))
             .ReturnsAsync([]);
 
-        var service = new AggregatedBikeDataService(blobStorage.Object);
+        var service = CreateService(blobStorage, EmptyStationsResponse);
 
         var result = await service.GetSnapshotsAsync(CancellationToken);
 
@@ -107,7 +124,7 @@ public sealed class AggregatedBikeDataServiceTests
                 }
             ]);
 
-        var service = new AggregatedBikeDataService(blobStorage.Object);
+        var service = CreateService(blobStorage, EmptyStationsResponse);
 
         var result = await service.GetAvailabilityAsync("station-001", CancellationToken);
 
@@ -133,11 +150,53 @@ public sealed class AggregatedBikeDataServiceTests
                 }
             ]);
 
-        var service = new AggregatedBikeDataService(blobStorage.Object);
+        var service = CreateService(blobStorage, EmptyStationsResponse);
 
         var result = await service.GetDestinationsAsync("station-001", CancellationToken);
 
         var destination = Assert.Single(result);
         Assert.Equal("station-002", destination.ArrivalStationId);
+    }
+
+    private const string EmptyStationsResponse = """
+        {
+          "data": {
+            "vehicleRentalStations": []
+          }
+        }
+        """;
+
+    private static AggregatedBikeDataService CreateService(Mock<IBikeDataBlobStorage> blobStorage, string liveStationsResponse)
+        => new(blobStorage.Object, CreateLiveStationCacheService(liveStationsResponse));
+
+    private static LiveStationCacheService CreateLiveStationCacheService(string responseBody)
+    {
+        var handler = new StubHttpMessageHandler(_ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(responseBody, Encoding.UTF8, "application/json")
+        }));
+
+        var client = new DigitransitStationClient(
+            new HttpClient(handler),
+            Options.Create(new PollStationsOptions
+            {
+                DigitransitSubscriptionKey = "test-subscription-key"
+            }));
+
+        return new LiveStationCacheService(
+            client,
+            new FixedTimeProvider(new DateTimeOffset(2026, 4, 6, 10, 0, 0, TimeSpan.Zero)),
+            NullLogger<LiveStationCacheService>.Instance);
+    }
+
+    private sealed class StubHttpMessageHandler(Func<HttpRequestMessage, Task<HttpResponseMessage>> handler) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => handler(request);
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset timestamp) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => timestamp;
     }
 }

--- a/tests/HslBikeDataAggregator.Tests/Services/LiveStationCacheServiceTests.cs
+++ b/tests/HslBikeDataAggregator.Tests/Services/LiveStationCacheServiceTests.cs
@@ -1,0 +1,124 @@
+using System.Net;
+using System.Text;
+
+using HslBikeDataAggregator.Configuration;
+using HslBikeDataAggregator.Services;
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace HslBikeDataAggregator.Tests.Services;
+
+public sealed class LiveStationCacheServiceTests
+{
+    [Fact]
+    public async Task GetStationsAsync_ReturnsCachedStationsUntilCacheExpires()
+    {
+        var requestCount = 0;
+        var handler = new StubHttpMessageHandler(_ =>
+        {
+            requestCount++;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(CreateStationsResponse("Central Station", 8), Encoding.UTF8, "application/json")
+            });
+        });
+
+        var timeProvider = new MutableTimeProvider(new DateTimeOffset(2026, 4, 6, 10, 0, 0, TimeSpan.Zero));
+        var service = CreateService(handler, timeProvider);
+
+        var first = await service.GetStationsAsync(TestContext.Current.CancellationToken);
+        timeProvider.SetUtcNow(timeProvider.GetUtcNow().AddMinutes(1));
+        var second = await service.GetStationsAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, requestCount);
+        Assert.Same(first, second);
+        Assert.Equal("Central Station", Assert.Single(second).Name);
+    }
+
+    [Fact]
+    public async Task GetStationsAsync_RefreshesStationsAfterCacheExpires()
+    {
+        var responses = new Queue<string>([
+            CreateStationsResponse("Central Station", 8),
+            CreateStationsResponse("Updated Station", 6)
+        ]);
+
+        var requestCount = 0;
+        var handler = new StubHttpMessageHandler(_ =>
+        {
+            requestCount++;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(responses.Dequeue(), Encoding.UTF8, "application/json")
+            });
+        });
+
+        var timeProvider = new MutableTimeProvider(new DateTimeOffset(2026, 4, 6, 10, 0, 0, TimeSpan.Zero));
+        var service = CreateService(handler, timeProvider);
+
+        _ = await service.GetStationsAsync(TestContext.Current.CancellationToken);
+        timeProvider.SetUtcNow(timeProvider.GetUtcNow().AddMinutes(2).AddSeconds(1));
+        var refreshed = await service.GetStationsAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, requestCount);
+        var station = Assert.Single(refreshed);
+        Assert.Equal("Updated Station", station.Name);
+        Assert.Equal(6, station.BikesAvailable);
+    }
+
+    private static LiveStationCacheService CreateService(HttpMessageHandler handler, TimeProvider timeProvider)
+    {
+        var client = new DigitransitStationClient(
+            new HttpClient(handler),
+            Options.Create(new PollStationsOptions
+            {
+                DigitransitSubscriptionKey = "test-subscription-key"
+            }));
+
+        return new LiveStationCacheService(client, timeProvider, NullLogger<LiveStationCacheService>.Instance);
+    }
+
+    private static string CreateStationsResponse(string stationName, int bikesAvailable)
+        => $$"""
+           {
+             "data": {
+               "vehicleRentalStations": [
+                 {
+                   "stationId": "station-001",
+                   "name": "{{stationName}}",
+                   "lat": 60.1708,
+                   "lon": 24.941,
+                   "allowPickup": true,
+                   "allowDropoff": true,
+                   "capacity": 24,
+                   "availableVehicles": {
+                     "byType": [
+                       { "count": {{bikesAvailable}} }
+                     ]
+                   },
+                   "availableSpaces": {
+                     "byType": [
+                       { "count": 16 }
+                     ]
+                   }
+                 }
+               ]
+             }
+           }
+           """;
+
+    private sealed class StubHttpMessageHandler(Func<HttpRequestMessage, Task<HttpResponseMessage>> handler) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => handler(request);
+    }
+
+    private sealed class MutableTimeProvider(DateTimeOffset currentTime) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => currentTime;
+
+        public void SetUtcNow(DateTimeOffset newCurrentTime)
+            => currentTime = newCurrentTime;
+    }
+}

--- a/tests/HslBikeDataAggregator.Tests/Services/PollStationsServiceTests.cs
+++ b/tests/HslBikeDataAggregator.Tests/Services/PollStationsServiceTests.cs
@@ -16,7 +16,7 @@ namespace HslBikeDataAggregator.Tests.Services;
 public sealed class PollStationsServiceTests
 {
     [Fact]
-    public async Task PollAsync_StoresLatestStationsAndTrimsSnapshotHistory()
+    public async Task PollAsync_StoresSnapshotsAndTrimsSnapshotHistory()
     {
         var capturedRequestBody = string.Empty;
         HttpRequestMessage? capturedRequest = null;
@@ -83,12 +83,6 @@ public sealed class PollStationsServiceTests
                 }
             ]);
 
-        IReadOnlyList<BikeStation>? latestStations = null;
-        blobStorage
-            .Setup(storage => storage.WriteLatestStationsAsync(It.IsAny<IReadOnlyList<BikeStation>>(), It.IsAny<CancellationToken>()))
-            .Callback<IReadOnlyList<BikeStation>, CancellationToken>((stations, _) => latestStations = stations)
-            .Returns(Task.CompletedTask);
-
         IReadOnlyList<StationSnapshot>? writtenSnapshots = null;
         blobStorage
             .Setup(storage => storage.WriteRecentSnapshotsAsync(It.IsAny<IReadOnlyList<StationSnapshot>>(), It.IsAny<CancellationToken>()))
@@ -118,13 +112,6 @@ public sealed class PollStationsServiceTests
         Assert.True(capturedRequest.Headers.TryGetValues("digitransit-subscription-key", out var headerValues));
         Assert.Contains("test-subscription-key", headerValues);
         Assert.Contains("vehicleRentalStations", capturedRequestBody);
-
-        var station = Assert.Single(latestStations!);
-        Assert.Equal("001", station.Id);
-        Assert.Equal("Central Station", station.Name);
-        Assert.Equal(9, station.BikesAvailable);
-        Assert.Equal(5, station.SpacesAvailable);
-        Assert.True(station.IsActive);
 
         Assert.NotNull(writtenSnapshots);
         Assert.Equal(2, writtenSnapshots!.Count);


### PR DESCRIPTION
## Summary
- replace blob-backed live station reads with a 2-minute in-memory Digitransit cache
- reduce snapshot polling defaults from 5 minutes to 15 minutes and stop writing `stations/latest.json`
- add HTTP `Cache-Control` headers and update dev/prod infrastructure and workflows for Flex Consumption side-by-side deployment

## Validation
- `dotnet build HslBikeDataAggregator.slnx`
- `dotnet test tests/HslBikeDataAggregator.Tests/HslBikeDataAggregator.Tests.csproj --configuration Release --no-build`

Closes #21