### PR TITLE
Remove RBAC role assignments from Bicep and document manual post-deployment steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,10 +136,55 @@ Azure infrastructure is defined in `infra/main.bicep` with environment parameter
 
 The template provisions:
 
-- Azure Functions hosting plan on the Consumption tier
-- Azure Function App
-- Storage account
-- Application Insights
+- Azure Functions Flex Consumption plan (FC1, Linux)
+- Azure Function App with system-assigned managed identity
+- Storage account (shared-key access disabled, OAuth-only)
+- Application Insights backed by Log Analytics workspace
+- Storage diagnostic settings
+
+### Post-deployment: assign storage RBAC roles
+
+The Function App uses a **managed identity** for storage access instead of connection strings. After the first deployment to a new environment (or after recreating the resource group), you must manually assign two RBAC roles to the managed identity.
+
+1. Deploy the infrastructure so the Function App and its managed identity are created.
+
+2. Retrieve the managed identity principal ID from the deployment outputs:
+
+   ```sh
+   az deployment group show \
+     --resource-group <resource-group> \
+     --name main \
+     --query properties.outputs.managedIdentityPrincipalId.value \
+     --output tsv
+   ```
+
+3. Assign the required storage roles:
+
+   ```sh
+   PRINCIPAL_ID="<principal-id-from-step-2>"
+   STORAGE_ACCOUNT=$(az deployment group show \
+     --resource-group <resource-group> \
+     --name main \
+     --query properties.outputs.storageAccountName.value \
+     --output tsv)
+   SCOPE="/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.Storage/storageAccounts/$STORAGE_ACCOUNT"
+
+   # Storage Blob Data Owner — read/write blobs (snapshots, availability, destinations)
+   az role assignment create \
+     --assignee "$PRINCIPAL_ID" \
+     --role "Storage Blob Data Owner" \
+     --scope "$SCOPE"
+
+   # Storage Queue Data Contributor — Azure Functions host internal queue access
+   az role assignment create \
+     --assignee "$PRINCIPAL_ID" \
+     --role "Storage Queue Data Contributor" \
+     --scope "$SCOPE"
+   ```
+
+4. Re-run the deployment workflow (or restart the Function App) so it picks up the new permissions.
+
+> **Note:** These role assignments are scoped to the storage account and will be deleted if the resource group is removed. Repeat step 3 after recreating the resource group.
 
 ### GitHub environments
 
@@ -152,10 +197,10 @@ Recommended names for this repository:
 
 - `dev`
   - `AZURE_RESOURCE_GROUP=rg-hsl-bike-data-aggregator-dev`
-  - `AZURE_FUNCTION_APP_NAME=func-hsl-bike-data-aggregator-dev`
+  - `AZURE_FUNCTION_APP_NAME=func-hsl-bike-data-aggregator-dev-flex`
 - `prod`
   - `AZURE_RESOURCE_GROUP=rg-hsl-bike-data-aggregator-prod`
-  - `AZURE_FUNCTION_APP_NAME=func-hsl-bike-data-aggregator-prod`
+  - `AZURE_FUNCTION_APP_NAME=func-hsl-bike-data-aggregator-prod-flex`
 
 Set these environment variables in each environment:
 
@@ -178,7 +223,7 @@ One-time Azure setup:
 
 1. Create an Entra application or service principal for GitHub Actions.
 2. Add a federated credential for this repository and the target GitHub environment.
-3. Grant the identity `Contributor` access to the target resource group.
+3. Grant the identity **Contributor** access to the target subscription (or resource group). No elevated roles such as User Access Administrator are required — RBAC for the managed identity is assigned manually (see above).
 
 ### Workflows
 

--- a/README.md
+++ b/README.md
@@ -137,14 +137,17 @@ Azure infrastructure is defined in `infra/main.bicep` with environment parameter
 The template provisions:
 
 - Azure Functions Flex Consumption plan (FC1, Linux)
-- Azure Function App with system-assigned managed identity
+- User-assigned managed identity (survives Function App deletion)
+- Azure Function App linked to the user-assigned identity
 - Storage account (shared-key access disabled, OAuth-only)
 - Application Insights backed by Log Analytics workspace
 - Storage diagnostic settings
 
 ### Post-deployment: assign storage RBAC roles
 
-The Function App uses a **managed identity** for storage access instead of connection strings. After the first deployment to a new environment (or after recreating the resource group), you must manually assign two RBAC roles to the managed identity.
+The Function App uses a **user-assigned managed identity** for storage access instead of connection strings. Because the identity is a separate Azure resource, it (and its RBAC roles) survive Function App deletion and recreation — you only need to assign roles once per environment unless the resource group itself is removed.
+
+After the first deployment to a new environment (or after recreating the resource group), assign two RBAC roles to the managed identity.
 
 1. Deploy the infrastructure so the Function App and its managed identity are created.
 
@@ -184,7 +187,7 @@ The Function App uses a **managed identity** for storage access instead of conne
 
 4. Re-run the deployment workflow (or restart the Function App) so it picks up the new permissions.
 
-> **Note:** These role assignments are scoped to the storage account and will be deleted if the resource group is removed. Repeat step 3 after recreating the resource group.
+> **Note:** The user-assigned managed identity is a standalone resource within the resource group. Deleting and recreating the Function App does not affect the identity or its role assignments. However, if the entire resource group is removed, repeat step 3 after recreating it.
 
 ### GitHub environments
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -36,11 +36,7 @@ var storageAccountName = take('st${toLower(replace(replace(functionAppName, '-',
 var deploymentStorageContainerName = 'deployment-packages'
 var deploymentStorageContainerUrl = 'https://${storageAccount.name}.blob.${environment().suffixes.storage}/${deploymentStorageContainerName}'
 
-// Built-in role definition IDs
-var storageBlobDataOwnerRoleId = 'b7e6dc6d-f1e8-4753-8033-0f276bb0955b'
-var storageQueueDataContributorRoleId = '974c5e8b-45b9-4653-ba55-5f855dd0fb88'
-
-resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+resource storageAccount
   name: storageAccountName
   location: location
   sku: {
@@ -193,27 +189,6 @@ resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
     'azd-env-name': environmentName
     environment: environmentName
     project: 'HslBikeDataAggregator'
-  }
-}
-
-// Role assignments for Managed Identity storage access
-resource storageBlobDataOwnerRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(storageAccount.id, functionApp.id, storageBlobDataOwnerRoleId)
-  scope: storageAccount
-  properties: {
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', storageBlobDataOwnerRoleId)
-    principalId: functionApp.identity.principalId
-    principalType: 'ServicePrincipal'
-  }
-}
-
-resource storageQueueDataContributorRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(storageAccount.id, functionApp.id, storageQueueDataContributorRoleId)
-  scope: storageAccount
-  properties: {
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', storageQueueDataContributorRoleId)
-    principalId: functionApp.identity.principalId
-    principalType: 'ServicePrincipal'
   }
 }
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -29,12 +29,23 @@ param snapshotHistoryLimit int = 60
 @description('Cron expression used by the ProcessStationHistory timer trigger.')
 param historyProcessingCron string = '0 0 2 * * *'
 
+var managedIdentityName = '${functionAppName}-id'
 var appServicePlanName = '${functionAppName}-plan'
 var applicationInsightsName = '${functionAppName}-appi'
 var logAnalyticsWorkspaceName = '${functionAppName}-law'
 var storageAccountName = take('st${toLower(replace(replace(functionAppName, '-', ''), '_', ''))}${uniqueString(resourceGroup().id)}', 24)
 var deploymentStorageContainerName = 'deployment-packages'
 var deploymentStorageContainerUrl = 'https://${storageAccount.name}.blob.${environment().suffixes.storage}/${deploymentStorageContainerName}'
+
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: managedIdentityName
+  location: location
+  tags: {
+    'azd-env-name': environmentName
+    environment: environmentName
+    project: 'HslBikeDataAggregator'
+  }
+}
 
 resource storageAccount
   name: storageAccountName
@@ -127,7 +138,10 @@ resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
   location: location
   kind: 'functionapp,linux'
   identity: {
-    type: 'SystemAssigned'
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${managedIdentity.id}': {}
+    }
   }
   properties: {
     serverFarmId: appServicePlan.id
@@ -139,7 +153,8 @@ resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
           type: 'blobContainer'
           value: deploymentStorageContainerUrl
           authentication: {
-            type: 'SystemAssignedIdentity'
+            type: 'UserAssignedIdentity'
+            userAssignedIdentityResourceId: managedIdentity.id
           }
         }
       }
@@ -162,6 +177,14 @@ resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
         {
           name: 'AzureWebJobsStorage__accountName'
           value: storageAccount.name
+        }
+        {
+          name: 'AzureWebJobsStorage__clientId'
+          value: managedIdentity.properties.clientId
+        }
+        {
+          name: 'AzureWebJobsStorage__credential'
+          value: 'managedidentity'
         }
         {
           name: 'PollIntervalCron'
@@ -226,4 +249,5 @@ output functionHostname string = 'https://${functionApp.properties.defaultHostNa
 output storageAccountName string = storageAccount.name
 output applicationInsightsName string = applicationInsights.name
 output logAnalyticsWorkspaceName string = logAnalyticsWorkspace.name
-output managedIdentityPrincipalId string = functionApp.identity.principalId
+output managedIdentityPrincipalId string = managedIdentity.properties.principalId
+output managedIdentityClientId string = managedIdentity.properties.clientId

--- a/src/HslBikeDataAggregator/Program.cs
+++ b/src/HslBikeDataAggregator/Program.cs
@@ -56,7 +56,14 @@ builder.Services.AddSingleton(provider =>
     if (!string.IsNullOrWhiteSpace(accountName))
     {
         var containerUri = new Uri($"https://{accountName}.blob.core.windows.net/{BikeDataBlobNames.ContainerName}");
-        return new BlobContainerClient(containerUri, new DefaultAzureCredential());
+
+        // Use user-assigned managed identity when a client ID is configured
+        var clientId = configuration["AzureWebJobsStorage__clientId"];
+        var credential = string.IsNullOrWhiteSpace(clientId)
+            ? new DefaultAzureCredential()
+            : new DefaultAzureCredential(new DefaultAzureCredentialOptions { ManagedIdentityClientId = clientId });
+
+        return new BlobContainerClient(containerUri, credential);
     }
 
     throw new InvalidOperationException("Storage is not configured. Set either AzureWebJobsStorage (local) or AzureWebJobsStorage__accountName (Azure).");

--- a/tests/HslBikeDataAggregator.Tests/Configuration/DeploymentWorkflowConfigurationTests.cs
+++ b/tests/HslBikeDataAggregator.Tests/Configuration/DeploymentWorkflowConfigurationTests.cs
@@ -197,16 +197,25 @@ public sealed class DeploymentWorkflowConfigurationTests
     }
 
     [Fact]
-    public async Task Infrastructure_AssignsStorageRbacRoles()
+    public async Task Infrastructure_OutputsManagedIdentityPrincipalId()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
         var mainBicep = await File.ReadAllTextAsync(GetRepositoryFilePath("infra", "main.bicep"), cancellationToken);
 
-        Assert.Contains("b7e6dc6d-f1e8-4753-8033-0f276bb0955b", mainBicep, StringComparison.Ordinal);
-        Assert.Contains("974c5e8b-45b9-4653-ba55-5f855dd0fb88", mainBicep, StringComparison.Ordinal);
-        Assert.Contains("storageBlobDataOwnerRole", mainBicep, StringComparison.Ordinal);
-        Assert.Contains("storageQueueDataContributorRole", mainBicep, StringComparison.Ordinal);
-        Assert.Contains("principalType: 'ServicePrincipal'", mainBicep, StringComparison.Ordinal);
+        Assert.Contains("output managedIdentityPrincipalId string", mainBicep, StringComparison.Ordinal);
+        Assert.DoesNotContain("Microsoft.Authorization/roleAssignments", mainBicep, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Readme_DocumentsManualRbacAssignment()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var readme = await File.ReadAllTextAsync(GetRepositoryFilePath("README.md"), cancellationToken);
+
+        Assert.Contains("Storage Blob Data Owner", readme, StringComparison.Ordinal);
+        Assert.Contains("Storage Queue Data Contributor", readme, StringComparison.Ordinal);
+        Assert.Contains("az role assignment create", readme, StringComparison.Ordinal);
+        Assert.Contains("managedIdentityPrincipalId", readme, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/HslBikeDataAggregator.Tests/Configuration/DeploymentWorkflowConfigurationTests.cs
+++ b/tests/HslBikeDataAggregator.Tests/Configuration/DeploymentWorkflowConfigurationTests.cs
@@ -192,8 +192,10 @@ public sealed class DeploymentWorkflowConfigurationTests
         Assert.Contains("defaultToOAuthAuthentication: true", mainBicep, StringComparison.Ordinal);
         Assert.Contains("AzureWebJobsStorage__accountName", mainBicep, StringComparison.Ordinal);
         Assert.DoesNotContain("AzureWebJobsStorage'", mainBicep, StringComparison.Ordinal);
-        Assert.Contains("type: 'SystemAssignedIdentity'", mainBicep, StringComparison.Ordinal);
-        Assert.Contains("type: 'SystemAssigned'", mainBicep, StringComparison.Ordinal);
+        Assert.Contains("type: 'UserAssignedIdentity'", mainBicep, StringComparison.Ordinal);
+        Assert.Contains("type: 'UserAssigned'", mainBicep, StringComparison.Ordinal);
+        Assert.Contains("AzureWebJobsStorage__clientId", mainBicep, StringComparison.Ordinal);
+        Assert.Contains("AzureWebJobsStorage__credential", mainBicep, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -203,7 +205,19 @@ public sealed class DeploymentWorkflowConfigurationTests
         var mainBicep = await File.ReadAllTextAsync(GetRepositoryFilePath("infra", "main.bicep"), cancellationToken);
 
         Assert.Contains("output managedIdentityPrincipalId string", mainBicep, StringComparison.Ordinal);
+        Assert.Contains("output managedIdentityClientId string", mainBicep, StringComparison.Ordinal);
         Assert.DoesNotContain("Microsoft.Authorization/roleAssignments", mainBicep, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Infrastructure_UsesUserAssignedManagedIdentity()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var mainBicep = await File.ReadAllTextAsync(GetRepositoryFilePath("infra", "main.bicep"), cancellationToken);
+
+        Assert.Contains("Microsoft.ManagedIdentity/userAssignedIdentities", mainBicep, StringComparison.Ordinal);
+        Assert.Contains("userAssignedIdentities:", mainBicep, StringComparison.Ordinal);
+        Assert.Contains("userAssignedIdentityResourceId:", mainBicep, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -216,6 +230,7 @@ public sealed class DeploymentWorkflowConfigurationTests
         Assert.Contains("Storage Queue Data Contributor", readme, StringComparison.Ordinal);
         Assert.Contains("az role assignment create", readme, StringComparison.Ordinal);
         Assert.Contains("managedIdentityPrincipalId", readme, StringComparison.Ordinal);
+        Assert.Contains("user-assigned managed identity", readme, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Remove `Microsoft.Authorization/roleAssignments` resources from `infra/main.bicep` so the deploying service principal only needs **Contributor** — no User Access Administrator required.

RBAC role assignments for the Function App's managed identity are now a one-time manual post-deployment step, documented in the README.

## Changes

### `infra/main.bicep`
- Remove `storageBlobDataOwnerRole` and `storageQueueDataContributorRole` resources
- Remove unused role definition ID variables
- Keep `managedIdentityPrincipalId` output for manual assignment

### `README.md`
- Update infrastructure description to reflect Flex Consumption architecture
- Add **Post-deployment: assign storage RBAC roles** section with step-by-step CLI commands
- Update default function app names to include `-flex` suffix
- Clarify that only Contributor is required for the deploying service principal

### Tests
- Replace `Infrastructure_AssignsStorageRbacRoles` with:
  - `Infrastructure_OutputsManagedIdentityPrincipalId` — verifies the output exists and no role assignment resources remain
  - `Readme_DocumentsManualRbacAssignment` — verifies the README contains the manual RBAC commands

## Why

The Bicep role assignment resources require `Microsoft.Authorization/roleAssignments/write` permission on the deploying service principal. This causes deployment failures when:
- The resource group is deleted and recreated (RG-scoped permissions are lost)
- A fresh environment is provisioned by a service principal with only Contributor

Moving RBAC to a manual step eliminates this dependency entirely.

Closes #34