### PR TITLE
fix: allow colons in station IDs for GBFS-format Digitransit IDs

### DIFF
--- a/src/HslBikeDataAggregator/Storage/BikeDataBlobNames.cs
+++ b/src/HslBikeDataAggregator/Storage/BikeDataBlobNames.cs
@@ -18,7 +18,7 @@ public static partial class BikeDataBlobNames
     public static string DestinationProfile(string stationId) => $"destinations/{SanitiseStationId(stationId)}.json";
 
     /// <summary>
-    /// Validates that a station ID contains only safe characters (alphanumeric, hyphens, underscores)
+    /// Validates that a station ID contains only safe characters (alphanumeric, hyphens, underscores, colons)
     /// to prevent path-traversal attacks in blob name construction.
     /// </summary>
     internal static string SanitiseStationId(string stationId)
@@ -33,6 +33,6 @@ public static partial class BikeDataBlobNames
         return stationId;
     }
 
-    [GeneratedRegex(@"^[\w\-]+$")]
+    [GeneratedRegex(@"^[\w\-:]+$")]
     private static partial Regex SafeStationIdPattern();
 }

--- a/tests/HslBikeDataAggregator.Tests/Functions/StationsFunctionsTests.cs
+++ b/tests/HslBikeDataAggregator.Tests/Functions/StationsFunctionsTests.cs
@@ -62,7 +62,7 @@ public sealed class StationsFunctionsTests
                   "data": {
                     "vehicleRentalStations": [
                       {
-                        "stationId": "station-001",
+                        "stationId": "smoove:001",
                         "name": "Central Station",
                         "lat": 60.1708,
                         "lon": 24.941,
@@ -94,7 +94,7 @@ public sealed class StationsFunctionsTests
 
         responseData.Body.Position = 0;
         using var reader = new StreamReader(responseData.Body);
-        Assert.Equal("[{\"id\":\"station-001\",\"name\":\"Central Station\",\"lat\":60.1708,\"lon\":24.941,\"capacity\":24,\"bikesAvailable\":8,\"spacesAvailable\":16,\"isActive\":true}]", await reader.ReadToEndAsync(cancellationToken));
+        Assert.Equal("[{\"id\":\"smoove:001\",\"name\":\"Central Station\",\"lat\":60.1708,\"lon\":24.941,\"capacity\":24,\"bikesAvailable\":8,\"spacesAvailable\":16,\"isActive\":true}]", await reader.ReadToEndAsync(cancellationToken));
     }
 
     [Fact]
@@ -136,8 +136,8 @@ public sealed class StationsFunctionsTests
                     Timestamp = new DateTimeOffset(2026, 4, 4, 9, 45, 0, TimeSpan.Zero),
                     BikeCounts = new Dictionary<string, int>
                     {
-                        ["station-001"] = 8,
-                        ["station-002"] = 3
+                        ["smoove:001"] = 8,
+                        ["smoove:002"] = 3
                     }
                 }
             ]);
@@ -152,7 +152,7 @@ public sealed class StationsFunctionsTests
 
         responseData.Body.Position = 0;
         using var reader = new StreamReader(responseData.Body);
-        Assert.Equal("[{\"timestamp\":\"2026-04-04T09:45:00+00:00\",\"bikeCounts\":{\"station-001\":8,\"station-002\":3}}]", await reader.ReadToEndAsync(cancellationToken));
+        Assert.Equal("[{\"timestamp\":\"2026-04-04T09:45:00+00:00\",\"bikeCounts\":{\"smoove:001\":8,\"smoove:002\":3}}]", await reader.ReadToEndAsync(cancellationToken));
     }
 
     [Fact]
@@ -183,11 +183,11 @@ public sealed class StationsFunctionsTests
         request.SetupGet(httpRequest => httpRequest.Headers).Returns(new HttpHeadersCollection());
         request.SetupGet(httpRequest => httpRequest.Identities).Returns(Array.Empty<ClaimsIdentity>());
         request.SetupGet(httpRequest => httpRequest.Method).Returns("GET");
-        request.SetupGet(httpRequest => httpRequest.Url).Returns(new Uri("https://localhost/api/stations/station-001/availability"));
+        request.SetupGet(httpRequest => httpRequest.Url).Returns(new Uri("https://localhost/api/stations/smoove:001/availability"));
 
         var blobStorage = new Mock<IBikeDataBlobStorage>();
         blobStorage
-            .Setup(storage => storage.GetAvailabilityProfileAsync("station-001", cancellationToken))
+            .Setup(storage => storage.GetAvailabilityProfileAsync("smoove:001", cancellationToken))
             .ReturnsAsync([
                 new HourlyAvailability
                 {
@@ -203,7 +203,7 @@ public sealed class StationsFunctionsTests
 
         var function = new StationsFunctions(CreateBikeDataService(blobStorage), NullLogger<StationsFunctions>.Instance);
 
-        var responseData = await function.GetStationAvailability(request.Object, "station-001", cancellationToken);
+        var responseData = await function.GetStationAvailability(request.Object, "smoove:001", cancellationToken);
 
         Assert.Equal(HttpStatusCode.OK, responseData.StatusCode);
         Assert.True(responseData.Headers.TryGetValues("Cache-Control", out var cacheControl));
@@ -242,16 +242,16 @@ public sealed class StationsFunctionsTests
         request.SetupGet(httpRequest => httpRequest.Headers).Returns(new HttpHeadersCollection());
         request.SetupGet(httpRequest => httpRequest.Identities).Returns(Array.Empty<ClaimsIdentity>());
         request.SetupGet(httpRequest => httpRequest.Method).Returns("GET");
-        request.SetupGet(httpRequest => httpRequest.Url).Returns(new Uri("https://localhost/api/stations/station-001/destinations"));
+        request.SetupGet(httpRequest => httpRequest.Url).Returns(new Uri("https://localhost/api/stations/smoove:001/destinations"));
 
         var blobStorage = new Mock<IBikeDataBlobStorage>();
         blobStorage
-            .Setup(storage => storage.GetStationDestinationsAsync("station-001", cancellationToken))
+            .Setup(storage => storage.GetStationDestinationsAsync("smoove:001", cancellationToken))
             .ReturnsAsync([
                 new StationHistory
                 {
-                    DepartureStationId = "station-001",
-                    ArrivalStationId = "station-002",
+                    DepartureStationId = "smoove:001",
+                    ArrivalStationId = "smoove:002",
                     TripCount = 12,
                     AverageDurationSeconds = 425.5,
                     AverageDistanceMetres = 1_280.2
@@ -260,7 +260,7 @@ public sealed class StationsFunctionsTests
 
         var function = new StationsFunctions(CreateBikeDataService(blobStorage), NullLogger<StationsFunctions>.Instance);
 
-        var responseData = await function.GetStationDestinations(request.Object, "station-001", cancellationToken);
+        var responseData = await function.GetStationDestinations(request.Object, "smoove:001", cancellationToken);
 
         Assert.Equal(HttpStatusCode.OK, responseData.StatusCode);
         Assert.True(responseData.Headers.TryGetValues("Cache-Control", out var cacheControl));
@@ -268,7 +268,7 @@ public sealed class StationsFunctionsTests
 
         responseData.Body.Position = 0;
         using var reader = new StreamReader(responseData.Body);
-        Assert.Equal("[{\"departureStationId\":\"station-001\",\"arrivalStationId\":\"station-002\",\"tripCount\":12,\"averageDurationSeconds\":425.5,\"averageDistanceMetres\":1280.2}]", await reader.ReadToEndAsync(cancellationToken));
+        Assert.Equal("[{\"departureStationId\":\"smoove:001\",\"arrivalStationId\":\"smoove:002\",\"tripCount\":12,\"averageDurationSeconds\":425.5,\"averageDistanceMetres\":1280.2}]", await reader.ReadToEndAsync(cancellationToken));
     }
 
     private const string EmptyStationsResponse = """

--- a/tests/HslBikeDataAggregator.Tests/Services/AggregatedBikeDataServiceTests.cs
+++ b/tests/HslBikeDataAggregator.Tests/Services/AggregatedBikeDataServiceTests.cs
@@ -29,7 +29,7 @@ public sealed class AggregatedBikeDataServiceTests
               "data": {
                 "vehicleRentalStations": [
                   {
-                    "stationId": "station-001",
+                    "stationId": "smoove:001",
                     "name": "Central Station",
                     "lat": 60.1708,
                     "lon": 24.941,
@@ -55,7 +55,7 @@ public sealed class AggregatedBikeDataServiceTests
         var result = await service.GetStationsAsync(CancellationToken);
 
         var station = Assert.Single(result);
-        Assert.Equal("station-001", station.Id);
+        Assert.Equal("smoove:001", station.Id);
     }
 
     [Fact]
@@ -82,7 +82,7 @@ public sealed class AggregatedBikeDataServiceTests
                     Timestamp = new DateTimeOffset(2026, 4, 4, 9, 45, 0, TimeSpan.Zero),
                     BikeCounts = new Dictionary<string, int>
                     {
-                        ["station-001"] = 8
+                        ["smoove:001"] = 8
                     }
                 }
             ]);
@@ -92,7 +92,7 @@ public sealed class AggregatedBikeDataServiceTests
         var result = await service.GetSnapshotsAsync(CancellationToken);
 
         var snapshot = Assert.Single(result);
-        Assert.Equal(8, snapshot.BikeCounts["station-001"]);
+        Assert.Equal(8, snapshot.BikeCounts["smoove:001"]);
     }
 
     [Fact]
@@ -115,7 +115,7 @@ public sealed class AggregatedBikeDataServiceTests
     {
         var blobStorage = new Mock<IBikeDataBlobStorage>();
         blobStorage
-            .Setup(storage => storage.GetAvailabilityProfileAsync("station-001", CancellationToken))
+            .Setup(storage => storage.GetAvailabilityProfileAsync("smoove:001", CancellationToken))
             .ReturnsAsync([
                 new HourlyAvailability
                 {
@@ -126,7 +126,7 @@ public sealed class AggregatedBikeDataServiceTests
 
         var service = CreateService(blobStorage, EmptyStationsResponse);
 
-        var result = await service.GetAvailabilityAsync("station-001", CancellationToken);
+        var result = await service.GetAvailabilityAsync("smoove:001", CancellationToken);
 
         var availability = Assert.Single(result);
         Assert.Equal(10, availability.Hour);
@@ -138,12 +138,12 @@ public sealed class AggregatedBikeDataServiceTests
     {
         var blobStorage = new Mock<IBikeDataBlobStorage>();
         blobStorage
-            .Setup(storage => storage.GetStationDestinationsAsync("station-001", CancellationToken))
+            .Setup(storage => storage.GetStationDestinationsAsync("smoove:001", CancellationToken))
             .ReturnsAsync([
                 new StationHistory
                 {
-                    DepartureStationId = "station-001",
-                    ArrivalStationId = "station-002",
+                    DepartureStationId = "smoove:001",
+                    ArrivalStationId = "smoove:002",
                     TripCount = 12,
                     AverageDurationSeconds = 425.5,
                     AverageDistanceMetres = 1_280.2
@@ -152,10 +152,10 @@ public sealed class AggregatedBikeDataServiceTests
 
         var service = CreateService(blobStorage, EmptyStationsResponse);
 
-        var result = await service.GetDestinationsAsync("station-001", CancellationToken);
+        var result = await service.GetDestinationsAsync("smoove:001", CancellationToken);
 
         var destination = Assert.Single(result);
-        Assert.Equal("station-002", destination.ArrivalStationId);
+        Assert.Equal("smoove:002", destination.ArrivalStationId);
     }
 
     private const string EmptyStationsResponse = """

--- a/tests/HslBikeDataAggregator.Tests/Services/AvailabilityProfileServiceTests.cs
+++ b/tests/HslBikeDataAggregator.Tests/Services/AvailabilityProfileServiceTests.cs
@@ -15,8 +15,8 @@ public sealed class AvailabilityProfileServiceTests
                 Timestamp = new DateTimeOffset(2026, 4, 4, 10, 5, 0, TimeSpan.Zero),
                 BikeCounts = new Dictionary<string, int>
                 {
-                    ["station-001"] = 7,
-                    ["station-002"] = 3
+                    ["smoove:001"] = 7,
+                    ["smoove:002"] = 3
                 }
             },
             new StationSnapshot
@@ -24,7 +24,7 @@ public sealed class AvailabilityProfileServiceTests
                 Timestamp = new DateTimeOffset(2026, 4, 4, 10, 35, 0, TimeSpan.Zero),
                 BikeCounts = new Dictionary<string, int>
                 {
-                    ["station-001"] = 9
+                    ["smoove:001"] = 9
                 }
             },
             new StationSnapshot
@@ -32,8 +32,8 @@ public sealed class AvailabilityProfileServiceTests
                 Timestamp = new DateTimeOffset(2026, 4, 4, 11, 5, 0, TimeSpan.Zero),
                 BikeCounts = new Dictionary<string, int>
                 {
-                    ["station-001"] = 5,
-                    ["station-002"] = 4
+                    ["smoove:001"] = 5,
+                    ["smoove:002"] = 4
                 }
             }
         };
@@ -42,7 +42,7 @@ public sealed class AvailabilityProfileServiceTests
 
         var profiles = service.BuildProfiles(snapshots);
 
-        var station001Profile = Assert.IsAssignableFrom<IReadOnlyList<HourlyAvailability>>(profiles["station-001"]);
+        var station001Profile = Assert.IsAssignableFrom<IReadOnlyList<HourlyAvailability>>(profiles["smoove:001"]);
         Assert.Collection(
             station001Profile,
             availability =>
@@ -56,7 +56,7 @@ public sealed class AvailabilityProfileServiceTests
                 Assert.Equal(5, availability.AverageBikesAvailable);
             });
 
-        var station002Profile = Assert.IsAssignableFrom<IReadOnlyList<HourlyAvailability>>(profiles["station-002"]);
+        var station002Profile = Assert.IsAssignableFrom<IReadOnlyList<HourlyAvailability>>(profiles["smoove:002"]);
         Assert.Collection(
             station002Profile,
             availability =>

--- a/tests/HslBikeDataAggregator.Tests/Services/PollStationsServiceTests.cs
+++ b/tests/HslBikeDataAggregator.Tests/Services/PollStationsServiceTests.cs
@@ -33,7 +33,7 @@ public sealed class PollStationsServiceTests
                       "data": {
                         "vehicleRentalStations": [
                           {
-                            "stationId": "001",
+                            "stationId": "smoove:001",
                             "name": "Central Station",
                             "lat": 60.1708,
                             "lon": 24.941,
@@ -117,9 +117,9 @@ public sealed class PollStationsServiceTests
         Assert.Equal(2, writtenSnapshots!.Count);
         Assert.Equal(new DateTimeOffset(2026, 4, 3, 10, 5, 0, TimeSpan.Zero), writtenSnapshots[0].Timestamp);
         Assert.Equal(timestamp, writtenSnapshots[1].Timestamp);
-        Assert.Equal(9, writtenSnapshots[1].BikeCounts["001"]);
+        Assert.Equal(9, writtenSnapshots[1].BikeCounts["smoove:001"]);
 
-        var station001Profile = Assert.IsAssignableFrom<IReadOnlyList<HourlyAvailability>>(writtenAvailabilityProfiles["001"]);
+        var station001Profile = Assert.IsAssignableFrom<IReadOnlyList<HourlyAvailability>>(writtenAvailabilityProfiles["smoove:001"]);
         var station001Availability = Assert.Single(station001Profile);
         Assert.Equal(10, station001Availability.Hour);
         Assert.Equal(9, station001Availability.AverageBikesAvailable);

--- a/tests/HslBikeDataAggregator.Tests/Storage/BikeDataBlobNamesTests.cs
+++ b/tests/HslBikeDataAggregator.Tests/Storage/BikeDataBlobNamesTests.cs
@@ -5,7 +5,7 @@ namespace HslBikeDataAggregator.Tests.Storage;
 public sealed class BikeDataBlobNamesTests
 {
     [Theory]
-    [InlineData("001", "availability/001.json")]
+    [InlineData("smoove:001", "availability/smoove:001.json")]
     [InlineData("HSL-042", "availability/HSL-042.json")]
     [InlineData("station_99", "availability/station_99.json")]
     public void AvailabilityProfile_ValidStationId_ReturnsSafeBlobName(string stationId, string expected)
@@ -16,7 +16,7 @@ public sealed class BikeDataBlobNamesTests
     }
 
     [Theory]
-    [InlineData("001", "destinations/001.json")]
+    [InlineData("smoove:001", "destinations/smoove:001.json")]
     [InlineData("HSL-042", "destinations/HSL-042.json")]
     [InlineData("station_99", "destinations/station_99.json")]
     public void DestinationProfile_ValidStationId_ReturnsSafeBlobName(string stationId, string expected)


### PR DESCRIPTION
## Summary

The `SanitiseStationId` regex in `BikeDataBlobNames` rejected valid Digitransit GBFS-format station IDs (e.g. `smoove:001`) because the pattern `^[\w\-]+$` did not allow colons. This caused the `PollStations` and `ProcessStationHistory` timer functions to fail when writing per-station blob data.

## Root cause

The security-hardening commit (8394533) introduced path-traversal protection with a regex that was too restrictive. Colons are safe characters for Azure Blob Storage blob names — the real path-traversal threats (`/`, `\`, `..`) were already blocked.

## Changes

- **`BikeDataBlobNames.cs`** — Widened regex to `^[\w\-:]+$` to allow colons.
- **All test files** — Updated station IDs from plain strings (e.g. `station-001`, `001`) to GBFS-format IDs with colons (e.g. `smoove:001`) so this class of issue is caught by CI going forward.

All 70 tests pass.

Closes #38