### PR TITLE
Retry polling when Digitransit API returns empty station list during cold start

### DIFF
--- a/src/HslBikeDataAggregator/Configuration/PollStationsOptions.cs
+++ b/src/HslBikeDataAggregator/Configuration/PollStationsOptions.cs
@@ -5,4 +5,15 @@ public sealed class PollStationsOptions
     public string DigitransitSubscriptionKey { get; set; } = string.Empty;
 
     public int SnapshotHistoryLimit { get; set; } = 60;
+
+    /// <summary>
+    /// Number of times to retry fetching stations when the API returns an empty list
+    /// (e.g. during cold start). Set to 0 to disable application-level retries.
+    /// </summary>
+    public int EmptyResponseRetryCount { get; set; } = 3;
+
+    /// <summary>
+    /// Delay in seconds between retries when the API returns an empty station list.
+    /// </summary>
+    public int EmptyResponseRetryDelaySeconds { get; set; } = 60;
 }

--- a/src/HslBikeDataAggregator/HslBikeDataAggregator.csproj
+++ b/src/HslBikeDataAggregator/HslBikeDataAggregator.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" OutputItemType="Analyzer" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.4.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/src/HslBikeDataAggregator/Program.cs
+++ b/src/HslBikeDataAggregator/Program.cs
@@ -20,6 +20,8 @@ builder.Services
     {
         options.DigitransitSubscriptionKey = configuration["DigitransitSubscriptionKey"] ?? string.Empty;
         options.SnapshotHistoryLimit = configuration.GetValue<int?>("SnapshotHistoryLimit") ?? 60;
+        options.EmptyResponseRetryCount = configuration.GetValue<int?>("EmptyResponseRetryCount") ?? 3;
+        options.EmptyResponseRetryDelaySeconds = configuration.GetValue<int?>("EmptyResponseRetryDelaySeconds") ?? 5;
     });
 
 builder.Services
@@ -35,7 +37,8 @@ builder.Services
             options.RollingWindowMonthCount);
     });
 
-builder.Services.AddHttpClient<DigitransitStationClient>();
+builder.Services.AddHttpClient<DigitransitStationClient>()
+    .AddStandardResilienceHandler();
 builder.Services.AddHttpClient<ProcessStationHistoryService>();
 builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddSingleton<LiveStationCacheService>();

--- a/src/HslBikeDataAggregator/Services/PollStationsService.cs
+++ b/src/HslBikeDataAggregator/Services/PollStationsService.cs
@@ -16,7 +16,38 @@ public sealed class PollStationsService(
 {
     public async Task<PollStationsResult> PollAsync(CancellationToken cancellationToken)
     {
-        var stations = await digitransitStationClient.FetchStationsAsync(cancellationToken);
+        var retryCount = Math.Max(0, options.Value.EmptyResponseRetryCount);
+        var retryDelay = TimeSpan.FromSeconds(Math.Max(1, options.Value.EmptyResponseRetryDelaySeconds));
+
+        IReadOnlyList<BikeStation> stations = [];
+
+        for (var attempt = 0; attempt <= retryCount; attempt++)
+        {
+            stations = await digitransitStationClient.FetchStationsAsync(cancellationToken);
+
+            if (stations.Count > 0)
+            {
+                break;
+            }
+
+            if (attempt < retryCount)
+            {
+                logger.LogWarning(
+                    "Digitransit API returned no stations (attempt {Attempt}/{MaxAttempts}); retrying in {Delay}s.",
+                    attempt + 1,
+                    retryCount + 1,
+                    retryDelay.TotalSeconds);
+
+                await Task.Delay(retryDelay, timeProvider, cancellationToken);
+            }
+        }
+
+        if (stations.Count == 0)
+        {
+            logger.LogWarning("Digitransit API returned no stations after {MaxAttempts} attempts; skipping snapshot write to avoid corrupting the time series.", retryCount + 1);
+            return new PollStationsResult(timeProvider.GetUtcNow(), 0, 0);
+        }
+
         var timestamp = timeProvider.GetUtcNow();
         var snapshotHistoryLimit = Math.Max(1, options.Value.SnapshotHistoryLimit);
         var existingTimeSeries = await bikeDataBlobStorage.GetSnapshotTimeSeriesAsync(cancellationToken) ?? SnapshotTimeSeries.Empty;

--- a/tests/HslBikeDataAggregator.Tests/Services/PollStationsServiceTests.cs
+++ b/tests/HslBikeDataAggregator.Tests/Services/PollStationsServiceTests.cs
@@ -290,6 +290,160 @@ public sealed class PollStationsServiceTests
         Assert.Equal([-1, -1, 7], station001.Counts);
     }
 
+    [Fact]
+    public async Task PollAsync_DoesNotWriteBlob_WhenApiReturnsNoStations()
+    {
+        var handler = new StubHttpMessageHandler(_ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(
+                """{"data":{"vehicleRentalStations":[]}}""",
+                Encoding.UTF8,
+                "application/json")
+        }));
+
+        var options = Options.Create(new PollStationsOptions
+        {
+            DigitransitSubscriptionKey = "test-key",
+            SnapshotHistoryLimit = 5,
+            EmptyResponseRetryCount = 0
+        });
+        var digitransitStationClient = new DigitransitStationClient(new HttpClient(handler), options);
+        var blobStorage = new Mock<IBikeDataBlobStorage>();
+        blobStorage
+            .Setup(storage => storage.GetSnapshotTimeSeriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SnapshotTimeSeries.Empty);
+
+        var timestamp = new DateTimeOffset(2026, 4, 3, 10, 10, 0, TimeSpan.Zero);
+        var service = new PollStationsService(
+            digitransitStationClient,
+            blobStorage.Object,
+            options,
+            new FixedTimeProvider(timestamp),
+            NullLogger<PollStationsService>.Instance);
+
+        var result = await service.PollAsync(TestContext.Current.CancellationToken);
+
+        blobStorage.Verify(
+            storage => storage.WriteSnapshotTimeSeriesAsync(It.IsAny<SnapshotTimeSeries>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        Assert.Equal(0, result.StationCount);
+        Assert.Equal(0, result.SnapshotCount);
+    }
+
+    [Fact]
+    public async Task PollAsync_RetriesAndSucceeds_WhenApiReturnsEmptyThenValidData()
+    {
+        var callCount = 0;
+        var handler = new StubHttpMessageHandler(_ =>
+        {
+            callCount++;
+            var json = callCount < 3
+                ? """{ "data": { "vehicleRentalStations": [] } }"""
+                : """
+                  {
+                    "data": {
+                      "vehicleRentalStations": [
+                        {
+                          "stationId": "smoove:001",
+                          "name": "Central Station",
+                          "lat": 60.17,
+                          "lon": 24.94,
+                          "allowPickup": true,
+                          "allowDropoff": true,
+                          "capacity": 24,
+                          "availableVehicles": { "byType": [{ "count": 5 }] },
+                          "availableSpaces": { "byType": [{ "count": 3 }] }
+                        }
+                      ]
+                    }
+                  }
+                  """;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json, Encoding.UTF8, "application/json")
+            });
+        });
+
+        var options = Options.Create(new PollStationsOptions
+        {
+            DigitransitSubscriptionKey = "test-key",
+            SnapshotHistoryLimit = 5,
+            EmptyResponseRetryCount = 3,
+            EmptyResponseRetryDelaySeconds = 1
+        });
+        var digitransitStationClient = new DigitransitStationClient(new HttpClient(handler), options);
+        var blobStorage = new Mock<IBikeDataBlobStorage>();
+        blobStorage
+            .Setup(storage => storage.GetSnapshotTimeSeriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SnapshotTimeSeries.Empty);
+        blobStorage
+            .Setup(storage => storage.WriteSnapshotTimeSeriesAsync(It.IsAny<SnapshotTimeSeries>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var timestamp = new DateTimeOffset(2026, 4, 3, 10, 10, 0, TimeSpan.Zero);
+        var service = new PollStationsService(
+            digitransitStationClient,
+            blobStorage.Object,
+            options,
+            new FixedTimeProvider(timestamp),
+            NullLogger<PollStationsService>.Instance);
+
+        var result = await service.PollAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(3, callCount);
+        Assert.Equal(1, result.StationCount);
+        blobStorage.Verify(
+            storage => storage.WriteSnapshotTimeSeriesAsync(It.IsAny<SnapshotTimeSeries>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task PollAsync_SkipsWrite_WhenAllRetriesExhausted()
+    {
+        var callCount = 0;
+        var handler = new StubHttpMessageHandler(_ =>
+        {
+            callCount++;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """{ "data": { "vehicleRentalStations": [] } }""",
+                    Encoding.UTF8,
+                    "application/json")
+            });
+        });
+
+        var options = Options.Create(new PollStationsOptions
+        {
+            DigitransitSubscriptionKey = "test-key",
+            SnapshotHistoryLimit = 5,
+            EmptyResponseRetryCount = 2,
+            EmptyResponseRetryDelaySeconds = 1
+        });
+        var digitransitStationClient = new DigitransitStationClient(new HttpClient(handler), options);
+        var blobStorage = new Mock<IBikeDataBlobStorage>();
+        blobStorage
+            .Setup(storage => storage.GetSnapshotTimeSeriesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SnapshotTimeSeries.Empty);
+
+        var timestamp = new DateTimeOffset(2026, 4, 3, 10, 10, 0, TimeSpan.Zero);
+        var service = new PollStationsService(
+            digitransitStationClient,
+            blobStorage.Object,
+            options,
+            new FixedTimeProvider(timestamp),
+            NullLogger<PollStationsService>.Instance);
+
+        var result = await service.PollAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(3, callCount); // 1 initial + 2 retries
+        Assert.Equal(0, result.StationCount);
+        Assert.Equal(0, result.SnapshotCount);
+        blobStorage.Verify(
+            storage => storage.WriteSnapshotTimeSeriesAsync(It.IsAny<SnapshotTimeSeries>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
     private sealed class StubHttpMessageHandler(Func<HttpRequestMessage, Task<HttpResponseMessage>> handler) : HttpMessageHandler
     {
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
@@ -299,5 +453,19 @@ public sealed class PollStationsServiceTests
     private sealed class FixedTimeProvider(DateTimeOffset timestamp) : TimeProvider
     {
         public override DateTimeOffset GetUtcNow() => timestamp;
+
+        public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+        {
+            // Fire the callback immediately so Task.Delay completes without waiting.
+            callback(state);
+            return new NoOpTimer();
+        }
+
+        private sealed class NoOpTimer : ITimer
+        {
+            public bool Change(TimeSpan dueTime, TimeSpan period) => false;
+            public void Dispose() { }
+            public ValueTask DisposeAsync() => default;
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes the \PollStations\ timer function incorrectly skipping snapshot writes during Azure Functions cold start, when the Digitransit API transiently returns an empty station list.

## Changes

### HTTP-level resilience
Added \AddStandardResilienceHandler()\ to the \DigitransitStationClient\ HttpClient registration. This provides automatic Polly-based retries with exponential back-off for transient transport failures (timeouts, 5xx, connection errors) that occur while outbound connections are being established during cold start.

### Application-level retry loop
Added a retry loop in \PollStationsService.PollAsync\ that retries fetching stations when the API returns HTTP 200 with an empty \ehicleRentalStations\ array. This is distinct from a transport failure and is not caught by the HTTP resilience handler.

### Configuration
Two new configurable app settings in \PollStationsOptions\:
- \EmptyResponseRetryCount\ — number of retries before giving up (default: 3)
- \EmptyResponseRetryDelaySeconds\ — delay between retries in seconds (default: 60)

Set \EmptyResponseRetryCount\ to \