### PR TITLE
Do not cache empty Digitransit response in LiveStationCacheService

### DIFF
--- a/src/HslBikeDataAggregator/Services/LiveStationCacheService.cs
+++ b/src/HslBikeDataAggregator/Services/LiveStationCacheService.cs
@@ -34,6 +34,13 @@ public sealed class LiveStationCacheService(
             }
 
             stations = await digitransitStationClient.FetchStationsAsync(cancellationToken);
+
+            if (stations.Count == 0)
+            {
+                logger.LogWarning("Digitransit API returned no stations; skipping cache write so the next request retries immediately.");
+                return stations;
+            }
+
             cachedStations = new CachedStations(stations, currentTime + CacheLifetime);
             logger.LogInformation("Fetched {StationCount} live stations from Digitransit and cached them until {ExpiresAt}.", stations.Count, cachedStations.ExpiresAt);
             return stations;

--- a/tests/HslBikeDataAggregator.Tests/Services/LiveStationCacheServiceTests.cs
+++ b/tests/HslBikeDataAggregator.Tests/Services/LiveStationCacheServiceTests.cs
@@ -67,6 +67,37 @@ public sealed class LiveStationCacheServiceTests
         Assert.Equal(6, station.BikesAvailable);
     }
 
+    [Fact]
+    public async Task GetStationsAsync_DoesNotCacheEmptyResponse_SoNextRequestRetries()
+    {
+        var responses = new Queue<string>([
+            """{"data":{"vehicleRentalStations":[]}}""",
+            CreateStationsResponse("Central Station", 5)
+        ]);
+
+        var requestCount = 0;
+        var handler = new StubHttpMessageHandler(_ =>
+        {
+            requestCount++;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(responses.Dequeue(), Encoding.UTF8, "application/json")
+            });
+        });
+
+        var timeProvider = new MutableTimeProvider(new DateTimeOffset(2026, 4, 6, 10, 0, 0, TimeSpan.Zero));
+        var service = CreateService(handler, timeProvider);
+
+        var empty = await service.GetStationsAsync(TestContext.Current.CancellationToken);
+        // Time does not advance — the second call must retry despite being within the normal cache window.
+        var populated = await service.GetStationsAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, requestCount);
+        Assert.Empty(empty);
+        var station = Assert.Single(populated);
+        Assert.Equal("Central Station", station.Name);
+    }
+
     private static LiveStationCacheService CreateService(HttpMessageHandler handler, TimeProvider timeProvider)
     {
         var client = new DigitransitStationClient(


### PR DESCRIPTION
## Problem

The previous fix (#47) added retry logic to the `PollStations` timer, but `GET /api/stations` follows a completely separate path: it calls `LiveStationCacheService`, which calls `DigitransitStationClient` directly on every cache miss.

When Digitransit transiently returns an empty `vehicleRentalStations` array (e.g. immediately after a cold start), `LiveStationCacheService` stored that empty list in its in-memory cache with the full **2-minute** TTL. Every `GET /api/stations` call for the next 2 minutes returned `[]` immediately without retrying Digitransit, keeping the endpoint broken long after the transient condition had passed.

## Fix

Only write to `cachedStations` when the fetched list is non-empty. If Digitransit returns empty, log a warning and return the empty list without caching it. The very next request will call Digitransit again.

## Test

New test `GetStationsAsync_DoesNotCacheEmptyResponse_SoNextRequestRetries` verifies that a second call made within the normal cache window still hits Digitransit when the first call returned an empty list.

All 3 `LiveStationCacheServiceTests` pass.

Closes #48