### PR TITLE
Fix CORS for GitHub account rename to TmiKuoste

### DIFF
--- a/infra/dev.bicepparam
+++ b/infra/dev.bicepparam
@@ -5,6 +5,7 @@ param functionAppName = 'func-hsl-bike-data-aggregator-dev-flex'
 param apimServiceName = 'apim-hsl-bike-data-aggregator-dev'
 param corsAllowedOrigins = [
   'https://kuoste.github.io'
+  'https://tmikuoste.github.io'
   'http://localhost:5000'
 ]
 param pollIntervalCron = '0 */15 * * * *'

--- a/infra/dev.json
+++ b/infra/dev.json
@@ -14,9 +14,10 @@
     "corsAllowedOrigins": {
       "value": [
         "https://kuoste.github.io",
+        "https://tmikuoste.github.io",
         "http://localhost:5000"
       ]
-    },
+    }
     "pollIntervalCron": {
       "value": "0 */15 * * * *"
     },

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -353,6 +353,7 @@ resource apimApiPolicy 'Microsoft.ApiManagement/service/apis/policies@2024-05-01
     <cors allow-credentials="false">
       <allowed-origins>
         <origin>https://kuoste.github.io</origin>
+        <origin>https://tmikuoste.github.io</origin>
       </allowed-origins>
       <allowed-methods>
         <method>GET</method>

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.42.1.51946",
-      "templateHash": "8435272939348383580"
+      "templateHash": "12666906528667991272"
     }
   },
   "parameters": {
@@ -403,7 +403,7 @@
       "name": "[format('{0}/{1}/{2}', parameters('apimServiceName'), 'hsl-bike-api', 'policy')]",
       "properties": {
         "format": "xml",
-        "value": "<policies>\r\n  <inbound>\r\n    <base />\r\n    <set-header name=\"x-functions-key\" exists-action=\"override\">\r\n      <value>{{function-host-key}}</value>\r\n    </set-header>\r\n    <cors allow-credentials=\"false\">\r\n      <allowed-origins>\r\n        <origin>https://kuoste.github.io</origin>\r\n      </allowed-origins>\r\n      <allowed-methods>\r\n        <method>GET</method>\r\n      </allowed-methods>\r\n      <allowed-headers>\r\n        <header>*</header>\r\n      </allowed-headers>\r\n    </cors>\r\n    <rate-limit calls=\"200\" renewal-period=\"60\" />\r\n    <cache-lookup vary-by-developer=\"false\" vary-by-developer-groups=\"false\" />\r\n  </inbound>\r\n  <backend>\r\n    <base />\r\n  </backend>\r\n  <outbound>\r\n    <base />\r\n    <cache-store duration=\"30\" />\r\n  </outbound>\r\n  <on-error>\r\n    <base />\r\n  </on-error>\r\n</policies>\r\n"
+        "value": "<policies>\r\n  <inbound>\r\n    <base />\r\n    <set-header name=\"x-functions-key\" exists-action=\"override\">\r\n      <value>{{function-host-key}}</value>\r\n    </set-header>\r\n    <cors allow-credentials=\"false\">\r\n      <allowed-origins>\r\n        <origin>https://kuoste.github.io</origin>\r\n        <origin>https://tmikuoste.github.io</origin>\r\n      </allowed-origins>\r\n      <allowed-methods>\r\n        <method>GET</method>\r\n      </allowed-methods>\r\n      <allowed-headers>\r\n        <header>*</header>\r\n      </allowed-headers>\r\n    </cors>\r\n    <rate-limit calls=\"200\" renewal-period=\"60\" />\r\n    <cache-lookup vary-by-developer=\"false\" vary-by-developer-groups=\"false\" />\r\n  </inbound>\r\n  <backend>\r\n    <base />\r\n  </backend>\r\n  <outbound>\r\n    <base />\r\n    <cache-store duration=\"30\" />\r\n  </outbound>\r\n  <on-error>\r\n    <base />\r\n  </on-error>\r\n</policies>\r\n"
       },
       "dependsOn": [
         "[resourceId('Microsoft.ApiManagement/service/apis', parameters('apimServiceName'), 'hsl-bike-api')]",

--- a/infra/prod.bicepparam
+++ b/infra/prod.bicepparam
@@ -5,6 +5,7 @@ param functionAppName = 'func-hsl-bike-data-aggregator-prod-flex'
 param apimServiceName = 'apim-hsl-bike-data-aggregator-prod'
 param corsAllowedOrigins = [
   'https://kuoste.github.io'
+  'https://tmikuoste.github.io'
 ]
 param pollIntervalCron = '0 */15 * * * *'
 param snapshotHistoryLimit = 60

--- a/infra/prod.json
+++ b/infra/prod.json
@@ -13,9 +13,10 @@
     },
     "corsAllowedOrigins": {
       "value": [
-        "https://kuoste.github.io"
+        "https://kuoste.github.io",
+        "https://tmikuoste.github.io"
       ]
-    },
+    }
     "pollIntervalCron": {
       "value": "0 */15 * * * *"
     },


### PR DESCRIPTION
## Summary

After renaming the GitHub account from Kuoste to TmiKuoste, the Blazor frontend at https://tmikuoste.github.io was blocked by CORS on every API call through the APIM gateway.

## Changes

- **infra/main.bicep** — added <origin>https://tmikuoste.github.io</origin> to the APIM inbound CORS policy
- **infra/dev.json / infra/prod.json** — added https://tmikuoste.github.io to corsAllowedOrigins
- **infra/dev.bicepparam / infra/prod.bicepparam** — added https://tmikuoste.github.io to corsAllowedOrigins
- **infra/main.json** — regenerated from main.bicep via z bicep build

Both https://kuoste.github.io and https://tmikuoste.github.io are allowed to support any cached links to the old origin.

All 33 deployment configuration tests pass.

Closes #56