### PR TITLE
Fix CORS for GitHub account rename to TmiKuoste

### DIFF
--- a/infra/dev.bicepparam
+++ b/infra/dev.bicepparam
@@ -6,7 +6,7 @@ param apimServiceName = 'apim-hsl-bike-data-aggregator-dev'
 param corsAllowedOrigins = [
   'https://kuoste.github.io'
   'https://tmikuoste.github.io'
-  'http://localhost:5000'
+  'http://localhost:5291'
 ]
 param pollIntervalCron = '0 */15 * * * *'
 param snapshotHistoryLimit = 60

--- a/infra/dev.json
+++ b/infra/dev.json
@@ -15,9 +15,9 @@
       "value": [
         "https://kuoste.github.io",
         "https://tmikuoste.github.io",
-        "http://localhost:5000"
+        "http://localhost:5291"
       ]
-    }
+    },
     "pollIntervalCron": {
       "value": "0 */15 * * * *"
     },


### PR DESCRIPTION
Fixes the dev parameter files broken by Dependabot PRs merging after the account-rename changes were already stashed locally.

Changes:
- Add missing comma after corsAllowedOrigins in infra/dev.json (introduced by merge conflict)
- Update localhost port from 5000 to 5291 in infra/dev.bicepparam and infra/dev.json
- Add https://tmikuoste.github.io to CORS allowed origins in both files

Closes #56