### PR TITLE
Fix CORS for GitHub account rename to TmiKuoste

### DIFF
--- a/tests/HslBikeDataAggregator.Tests/Configuration/DeploymentWorkflowConfigurationTests.cs
+++ b/tests/HslBikeDataAggregator.Tests/Configuration/DeploymentWorkflowConfigurationTests.cs
@@ -150,12 +150,12 @@ public sealed class DeploymentWorkflowConfigurationTests
         Assert.Contains("allowedOrigins: corsAllowedOrigins", mainBicep, StringComparison.Ordinal);
 
         Assert.Contains("\"corsAllowedOrigins\"", devJson, StringComparison.Ordinal);
-        Assert.Contains("http://localhost:5000", devJson, StringComparison.Ordinal);
+        Assert.Contains("http://localhost:5291", devJson, StringComparison.Ordinal);
         Assert.Contains("\"corsAllowedOrigins\"", prodJson, StringComparison.Ordinal);
         Assert.DoesNotContain("localhost", prodJson, StringComparison.Ordinal);
 
         Assert.Contains("param corsAllowedOrigins", devBicepParameters, StringComparison.Ordinal);
-        Assert.Contains("http://localhost:5000", devBicepParameters, StringComparison.Ordinal);
+        Assert.Contains("http://localhost:5291", devBicepParameters, StringComparison.Ordinal);
         Assert.Contains("param corsAllowedOrigins", prodBicepParameters, StringComparison.Ordinal);
         Assert.DoesNotContain("localhost", prodBicepParameters, StringComparison.Ordinal);
     }


### PR DESCRIPTION
Updates the localhost port from 5000 to 5291 in dev parameter files and fixes the corresponding test assertion.

Changes:
- Update \http://localhost:5000\ to \http://localhost:5291\ in \infra/dev.bicepparam\ and \infra/dev.json\
- Update port assertion in \DeploymentWorkflowConfigurationTests\

Closes #56