### PR TITLE
Finish issue 60 APIM-only CORS and bicepparam deployment

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -87,7 +87,7 @@ jobs:
             az deployment group create \
               --resource-group "$AZURE_RESOURCE_GROUP" \
               --template-file infra/main.bicep \
-              --parameters @infra/dev.json \
+              --parameters infra/dev.bicepparam \
               functionAppName="$AZURE_FUNCTION_APP_NAME" \
               location="$AZURE_LOCATION"
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -99,7 +99,7 @@ jobs:
             az deployment group create \
               --resource-group "$AZURE_RESOURCE_GROUP" \
               --template-file infra/main.bicep \
-              --parameters @infra/prod.json \
+              --parameters infra/prod.bicepparam \
               functionAppName="$AZURE_FUNCTION_APP_NAME" \
               location="$AZURE_LOCATION"
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -18,10 +18,8 @@ param functionAppName string
 @minLength(2)
 param apimServiceName string
 
-@description('Frontend origins allowed by Azure Functions CORS configuration.')
-param corsAllowedOrigins array = [
-  'https://kuoste.github.io'
-]
+@description('Frontend origins allowed by the API Management CORS policy.')
+param corsAllowedOrigins array
 
 @description('Cron expression used by the PollStations timer trigger.')
 param pollIntervalCron string = '0 */15 * * * *'
@@ -40,6 +38,7 @@ var logAnalyticsWorkspaceName = '${functionAppName}-law'
 var storageAccountName = take('st${toLower(replace(replace(functionAppName, '-', ''), '_', ''))}${uniqueString(resourceGroup().id)}', 24)
 var deploymentStorageContainerName = 'deployment-packages'
 var deploymentStorageContainerUrl = 'https://${storageAccount.name}.blob.${environment().suffixes.storage}/${deploymentStorageContainerName}'
+var apimCorsAllowedOriginsXml = join(map(corsAllowedOrigins, origin => '        <origin>${origin}</origin>'), '\n')
 
 resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
   name: managedIdentityName
@@ -209,10 +208,6 @@ resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
           value: historyProcessingCron
         }
       ]
-      cors: {
-        allowedOrigins: corsAllowedOrigins
-        supportCredentials: false
-      }
       ftpsState: 'Disabled'
       http20Enabled: true
       minTlsVersion: '1.2'
@@ -360,8 +355,7 @@ resource apimApiPolicy 'Microsoft.ApiManagement/service/apis/policies@2024-05-01
     </set-header>
     <cors allow-credentials="false">
       <allowed-origins>
-        <origin>https://kuoste.github.io</origin>
-        <origin>https://tmikuoste.github.io</origin>
+${apimCorsAllowedOriginsXml}
       </allowed-origins>
       <allowed-methods>
         <method>GET</method>

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -39,6 +39,39 @@ var storageAccountName = take('st${toLower(replace(replace(functionAppName, '-',
 var deploymentStorageContainerName = 'deployment-packages'
 var deploymentStorageContainerUrl = 'https://${storageAccount.name}.blob.${environment().suffixes.storage}/${deploymentStorageContainerName}'
 var apimCorsAllowedOriginsXml = join(map(corsAllowedOrigins, origin => '        <origin>${origin}</origin>'), '\n')
+var apimApiPolicyTemplate = '''
+<policies>
+  <inbound>
+    <base />
+    <set-header name="x-functions-key" exists-action="override">
+      <value>{{function-host-key}}</value>
+    </set-header>
+    <cors allow-credentials="false">
+      <allowed-origins>
+__APIM_CORS_ALLOWED_ORIGINS__
+      </allowed-origins>
+      <allowed-methods>
+        <method>GET</method>
+      </allowed-methods>
+      <allowed-headers>
+        <header>*</header>
+      </allowed-headers>
+    </cors>
+    <rate-limit calls="200" renewal-period="60" />
+    <cache-lookup vary-by-developer="false" vary-by-developer-groups="false" />
+  </inbound>
+  <backend>
+    <base />
+  </backend>
+  <outbound>
+    <base />
+    <cache-store duration="30" />
+  </outbound>
+  <on-error>
+    <base />
+  </on-error>
+</policies>
+'''
 
 resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
   name: managedIdentityName
@@ -346,39 +379,7 @@ resource apimApiPolicy 'Microsoft.ApiManagement/service/apis/policies@2024-05-01
   parent: apimApi
   properties: {
     format: 'xml'
-    value: '''
-<policies>
-  <inbound>
-    <base />
-    <set-header name="x-functions-key" exists-action="override">
-      <value>{{function-host-key}}</value>
-    </set-header>
-    <cors allow-credentials="false">
-      <allowed-origins>
-${apimCorsAllowedOriginsXml}
-      </allowed-origins>
-      <allowed-methods>
-        <method>GET</method>
-      </allowed-methods>
-      <allowed-headers>
-        <header>*</header>
-      </allowed-headers>
-    </cors>
-    <rate-limit calls="200" renewal-period="60" />
-    <cache-lookup vary-by-developer="false" vary-by-developer-groups="false" />
-  </inbound>
-  <backend>
-    <base />
-  </backend>
-  <outbound>
-    <base />
-    <cache-store duration="30" />
-  </outbound>
-  <on-error>
-    <base />
-  </on-error>
-</policies>
-'''
+    value: replace(apimApiPolicyTemplate, '__APIM_CORS_ALLOWED_ORIGINS__', apimCorsAllowedOriginsXml)
   }
   dependsOn: [
     apimFunctionKeyNamedValue

--- a/src/HslBikeDataAggregator/local.settings.example.json
+++ b/src/HslBikeDataAggregator/local.settings.example.json
@@ -6,9 +6,5 @@
     "DigitransitSubscriptionKey": "",
     "PollIntervalCron": "0 */15 * * * *",
     "SnapshotHistoryLimit": "60"
-  },
-  "Host": {
-    "CORS": "https://kuoste.github.io,https://tmikuoste.github.io,http://localhost:5291",
-    "CORSCredentials": false
   }
 }

--- a/tests/HslBikeDataAggregator.Tests/Configuration/DeploymentWorkflowConfigurationTests.cs
+++ b/tests/HslBikeDataAggregator.Tests/Configuration/DeploymentWorkflowConfigurationTests.cs
@@ -32,7 +32,7 @@ public sealed class DeploymentWorkflowConfigurationTests
         var yaml = await File.ReadAllTextAsync(GetRepositoryFilePath(".github", "workflows", "deploy-dev.yml"), cancellationToken);
 
         Assert.Contains("environment: dev", yaml, StringComparison.Ordinal);
-        Assert.Contains("@infra/dev.json", yaml, StringComparison.Ordinal);
+        Assert.Contains("--parameters infra/dev.bicepparam", yaml, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -42,7 +42,7 @@ public sealed class DeploymentWorkflowConfigurationTests
         var yaml = await File.ReadAllTextAsync(GetRepositoryFilePath(".github", "workflows", "deploy-prod.yml"), cancellationToken);
 
         Assert.Contains("environment: prod", yaml, StringComparison.Ordinal);
-        Assert.Contains("@infra/prod.json", yaml, StringComparison.Ordinal);
+        Assert.Contains("--parameters infra/prod.bicepparam", yaml, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -87,15 +87,11 @@ public sealed class DeploymentWorkflowConfigurationTests
     {
         var cancellationToken = TestContext.Current.CancellationToken;
         var mainBicep = await File.ReadAllTextAsync(GetRepositoryFilePath("infra", "main.bicep"), cancellationToken);
-        var devJson = await File.ReadAllTextAsync(GetRepositoryFilePath("infra", "dev.json"), cancellationToken);
-        var prodJson = await File.ReadAllTextAsync(GetRepositoryFilePath("infra", "prod.json"), cancellationToken);
         var devBicepParameters = await File.ReadAllTextAsync(GetRepositoryFilePath("infra", "dev.bicepparam"), cancellationToken);
         var prodBicepParameters = await File.ReadAllTextAsync(GetRepositoryFilePath("infra", "prod.bicepparam"), cancellationToken);
 
         Assert.Contains("param historyProcessingCron string", mainBicep, StringComparison.Ordinal);
         Assert.Contains("name: 'HistoryProcessingCron'", mainBicep, StringComparison.Ordinal);
-        Assert.Contains("\"historyProcessingCron\"", devJson, StringComparison.Ordinal);
-        Assert.Contains("\"historyProcessingCron\"", prodJson, StringComparison.Ordinal);
         Assert.Contains("param historyProcessingCron = '0 0 2 * * *'", devBicepParameters, StringComparison.Ordinal);
         Assert.Contains("param historyProcessingCron = '0 0 2 * * *'", prodBicepParameters, StringComparison.Ordinal);
     }
@@ -105,16 +101,10 @@ public sealed class DeploymentWorkflowConfigurationTests
     {
         var cancellationToken = TestContext.Current.CancellationToken;
         var mainBicep = await File.ReadAllTextAsync(GetRepositoryFilePath("infra", "main.bicep"), cancellationToken);
-        var devJson = await File.ReadAllTextAsync(GetRepositoryFilePath("infra", "dev.json"), cancellationToken);
-        var prodJson = await File.ReadAllTextAsync(GetRepositoryFilePath("infra", "prod.json"), cancellationToken);
         var devBicepParameters = await File.ReadAllTextAsync(GetRepositoryFilePath("infra", "dev.bicepparam"), cancellationToken);
         var prodBicepParameters = await File.ReadAllTextAsync(GetRepositoryFilePath("infra", "prod.bicepparam"), cancellationToken);
 
         Assert.Contains("param pollIntervalCron string = '0 */15 * * * *'", mainBicep, StringComparison.Ordinal);
-        Assert.Contains("\"pollIntervalCron\"", devJson, StringComparison.Ordinal);
-        Assert.Contains("\"pollIntervalCron\"", prodJson, StringComparison.Ordinal);
-        Assert.Contains("\"0 */15 * * * *\"", devJson, StringComparison.Ordinal);
-        Assert.Contains("\"0 */15 * * * *\"", prodJson, StringComparison.Ordinal);
         Assert.Contains("param pollIntervalCron = '0 */15 * * * *'", devBicepParameters, StringComparison.Ordinal);
         Assert.Contains("param pollIntervalCron = '0 */15 * * * *'", prodBicepParameters, StringComparison.Ordinal);
     }
@@ -141,18 +131,13 @@ public sealed class DeploymentWorkflowConfigurationTests
     {
         var cancellationToken = TestContext.Current.CancellationToken;
         var mainBicep = await File.ReadAllTextAsync(GetRepositoryFilePath("infra", "main.bicep"), cancellationToken);
-        var devJson = await File.ReadAllTextAsync(GetRepositoryFilePath("infra", "dev.json"), cancellationToken);
-        var prodJson = await File.ReadAllTextAsync(GetRepositoryFilePath("infra", "prod.json"), cancellationToken);
         var devBicepParameters = await File.ReadAllTextAsync(GetRepositoryFilePath("infra", "dev.bicepparam"), cancellationToken);
         var prodBicepParameters = await File.ReadAllTextAsync(GetRepositoryFilePath("infra", "prod.bicepparam"), cancellationToken);
 
         Assert.Contains("param corsAllowedOrigins array", mainBicep, StringComparison.Ordinal);
-        Assert.Contains("allowedOrigins: corsAllowedOrigins", mainBicep, StringComparison.Ordinal);
-
-        Assert.Contains("\"corsAllowedOrigins\"", devJson, StringComparison.Ordinal);
-        Assert.Contains("http://localhost:5291", devJson, StringComparison.Ordinal);
-        Assert.Contains("\"corsAllowedOrigins\"", prodJson, StringComparison.Ordinal);
-        Assert.DoesNotContain("localhost", prodJson, StringComparison.Ordinal);
+        Assert.Contains("var apimCorsAllowedOriginsXml = join(map(corsAllowedOrigins", mainBicep, StringComparison.Ordinal);
+        Assert.Contains("${apimCorsAllowedOriginsXml}", mainBicep, StringComparison.Ordinal);
+        Assert.DoesNotContain("allowedOrigins: corsAllowedOrigins", mainBicep, StringComparison.Ordinal);
 
         Assert.Contains("param corsAllowedOrigins", devBicepParameters, StringComparison.Ordinal);
         Assert.Contains("http://localhost:5291", devBicepParameters, StringComparison.Ordinal);

--- a/tests/HslBikeDataAggregator.Tests/Configuration/DeploymentWorkflowConfigurationTests.cs
+++ b/tests/HslBikeDataAggregator.Tests/Configuration/DeploymentWorkflowConfigurationTests.cs
@@ -136,7 +136,8 @@ public sealed class DeploymentWorkflowConfigurationTests
 
         Assert.Contains("param corsAllowedOrigins array", mainBicep, StringComparison.Ordinal);
         Assert.Contains("var apimCorsAllowedOriginsXml = join(map(corsAllowedOrigins", mainBicep, StringComparison.Ordinal);
-        Assert.Contains("${apimCorsAllowedOriginsXml}", mainBicep, StringComparison.Ordinal);
+        Assert.Contains("var apimApiPolicyTemplate =", mainBicep, StringComparison.Ordinal);
+        Assert.Contains("value: replace(apimApiPolicyTemplate, '__APIM_CORS_ALLOWED_ORIGINS__', apimCorsAllowedOriginsXml)", mainBicep, StringComparison.Ordinal);
         Assert.DoesNotContain("allowedOrigins: corsAllowedOrigins", mainBicep, StringComparison.Ordinal);
 
         Assert.Contains("param corsAllowedOrigins", devBicepParameters, StringComparison.Ordinal);

--- a/tests/HslBikeDataAggregator.Tests/Configuration/ScaffoldConfigurationTests.cs
+++ b/tests/HslBikeDataAggregator.Tests/Configuration/ScaffoldConfigurationTests.cs
@@ -20,20 +20,13 @@ public sealed class ScaffoldConfigurationTests
     }
 
     [Fact]
-    public async Task LocalSettingsTemplate_ContainsGitHubPagesAndLocalhostCorsOrigins()
+    public async Task LocalSettingsTemplate_DoesNotContainHostSection()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
         var json = await File.ReadAllTextAsync(GetRepositoryFilePath("src", "HslBikeDataAggregator", "local.settings.example.json"), cancellationToken);
         using var document = JsonDocument.Parse(json);
 
-        var corsOrigin = document.RootElement
-            .GetProperty("Host")
-            .GetProperty("CORS")
-            .GetString();
-
-        Assert.Contains("https://kuoste.github.io", corsOrigin);
-        Assert.Contains("https://tmikuoste.github.io", corsOrigin);
-        Assert.Contains("http://localhost:5291", corsOrigin);
+        Assert.False(document.RootElement.TryGetProperty("Host", out _));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- make APIM the only CORS authority in the Bicep template
- deploy dev and prod infrastructure with the existing .bicepparam files
- remove obsolete local host CORS settings and align configuration tests

## Validation
- dotnet build HslBikeDataAggregator.slnx
- ran configuration tests for DeploymentWorkflowConfigurationTests and ScaffoldConfigurationTests

Closes #60