### PR TITLE
feat: OpenData polling framework + Uimastadion fill level source

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -109,6 +109,23 @@ jobs:
               --name "$AZURE_FUNCTION_APP_NAME" \
               --settings HistoryProcessingCron="${{ vars.HISTORY_PROCESSING_CRON || '0 0 2 * * *' }}"
 
+      - name: Configure open data settings
+        uses: azure/cli@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
+        with:
+          inlineScript: |
+            az functionapp config appsettings set \
+              --resource-group "$AZURE_RESOURCE_GROUP" \
+              --name "$AZURE_FUNCTION_APP_NAME" \
+              --settings \
+                OpenDataPollIntervalCron="${{ secrets.OPEN_DATA_POLL_INTERVAL_CRON || '0 */15 * * * *' }}" \
+                "OpenData__VenueFillLevelSources__0__SourceId=uimastadion" \
+                "OpenData__VenueFillLevelSources__0__DisplayName=Uimastadion" \
+                "OpenData__VenueFillLevelSources__0__Lat=60.1857" \
+                "OpenData__VenueFillLevelSources__0__Lon=24.9282" \
+                "OpenData__VenueFillLevelSources__0__AttributionUrl=https://helsinki.jaskaretail.com/current-fill-level/info/uimastadion" \
+                "OpenData__VenueFillLevelSources__0__LocationId=180" \
+                "OpenData__VenueFillLevelSources__0__LocationUrlName=uimastadion"
+
       - name: Deploy Function App package
         uses: Azure/functions-action@bc63708cc6539760eea18d8a7de4ce8ef5fdf593 # v1
         with:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -121,6 +121,23 @@ jobs:
               --name "$AZURE_FUNCTION_APP_NAME" \
               --settings HistoryProcessingCron="${{ vars.HISTORY_PROCESSING_CRON || '0 0 2 * * *' }}"
 
+      - name: Configure open data settings
+        uses: azure/cli@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
+        with:
+          inlineScript: |
+            az functionapp config appsettings set \
+              --resource-group "$AZURE_RESOURCE_GROUP" \
+              --name "$AZURE_FUNCTION_APP_NAME" \
+              --settings \
+                OpenDataPollIntervalCron="${{ secrets.OPEN_DATA_POLL_INTERVAL_CRON || '0 */15 * * * *' }}" \
+                "OpenData__VenueFillLevelSources__0__SourceId=uimastadion" \
+                "OpenData__VenueFillLevelSources__0__DisplayName=Uimastadion" \
+                "OpenData__VenueFillLevelSources__0__Lat=60.1857" \
+                "OpenData__VenueFillLevelSources__0__Lon=24.9282" \
+                "OpenData__VenueFillLevelSources__0__AttributionUrl=https://helsinki.jaskaretail.com/current-fill-level/info/uimastadion" \
+                "OpenData__VenueFillLevelSources__0__LocationId=180" \
+                "OpenData__VenueFillLevelSources__0__LocationUrlName=uimastadion"
+
       - name: Deploy Function App package
         uses: Azure/functions-action@bc63708cc6539760eea18d8a7de4ce8ef5fdf593 # v1
         with:

--- a/docs/adr/004-open-data-polling-framework.md
+++ b/docs/adr/004-open-data-polling-framework.md
@@ -1,0 +1,57 @@
+# ADR-004: Generic Open Data Polling Framework
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-18
+
+## Context
+
+The system needs to poll external open data sources — starting with Uimastadion swimmer fill level — and expose their time series via the same REST API that serves bike availability data. Several design questions arose:
+
+1. **One function per source vs. a generic framework** — should each new data source get its own timer-triggered function, or should all sources share a single timer and a common abstraction?
+2. **How to represent missing or unavailable data** — Uimastadion is seasonal; the external API may return no data outside the swim season, or fail transiently.
+3. **Where to store source metadata** — display name, coordinates, and attribution URL are needed at read time. Should they be derived from config at read time, or embedded in the blob?
+4. **DI registration for multiple source instances** — using `IEnumerable<T>` registration via `AddSingleton<T, TImpl>` would allow auto-resolution, but conflicts with the way the isolated worker host resolves constructor parameters.
+
+## Decisions
+
+### 1. Generic `IOpenDataSource` framework
+
+A single `PollOpenDataFunction` fans out over `IReadOnlyList<IOpenDataSource>`. New sources are added by implementing `IOpenDataSource` and registering a new entry in the config; no new function file is required.
+
+**Rationale:** The polling schedule is the same for all sources. A bespoke function per source would duplicate the retry/sentinel/blob-write logic and spread config across multiple timer expressions.
+
+### 2. `-1` sentinel for missing or failed values
+
+`IOpenDataSource.FetchAsync` returns `double?`. A `null` return signals that the value is currently unavailable (e.g. out of season). An unhandled exception is caught by the poll service. Both cases record `-1` in the time series, consistent with the `-1` convention already used in snapshot data for stations not yet seen.
+
+**Rationale:** Clients can distinguish "no data yet" (empty array) from "known-unavailable" (`-1`), enabling future UI treatment such as greying out a card outside season.
+
+### 3. Metadata embedded in each blob write
+
+`OpenDataTimeSeries` carries `displayName`, `lat`, `lon`, and `attributionUrl` alongside the time series data. These fields are refreshed from the source configuration on every poll write.
+
+**Rationale:** `GetOpenDataFunction` reads blobs in parallel without needing access to the source configuration at read time, keeping the HTTP path simple. Config updates (e.g. a renamed display name) propagate automatically on the next successful poll.
+
+### 4. `IReadOnlyList<IOpenDataSource>` registered via a factory singleton
+
+Rather than `AddSingleton<IOpenDataSource, VenueFillLevelSource>` (which would allow only one implementation), sources are registered as `IReadOnlyList<IOpenDataSource>` via a factory delegate that reads `OpenDataOptions.VenueFillLevelSources` at startup.
+
+**Rationale:** The isolated worker host resolves constructor parameters by exact type. `IEnumerable<IOpenDataSource>` can conflict with how the DI container resolves open-generic enumerables. `IReadOnlyList<T>` is unambiguous and clearly communicates that the list is fixed at startup.
+
+## Consequences
+
+### Positive
+
+- New open data sources require only a config entry and an `IOpenDataSource` implementation — no new function boilerplate.
+- Single failure isolation: one source throwing does not affect others in the same poll cycle.
+- Blob path `open-data/{sourceId}/recent.json` keeps open data segregated from bike data within the same container.
+
+### Negative
+
+- All sources share the same poll interval (`OpenDataPollIntervalCron`). If sources need different intervals in future, the framework would need to be extended.
+- Metadata staleness: if a source is removed from config but its blob remains, stale blobs are not automatically cleaned up.

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -31,6 +31,9 @@ param snapshotHistoryLimit int = 60
 @description('Cron expression used by the ProcessStationHistory timer trigger.')
 param historyProcessingCron string = '0 0 2 * * *'
 
+@description('Cron expression used by the PollOpenData timer trigger.')
+param openDataPollIntervalCron string = '0 */15 * * * *'
+
 var managedIdentityName = '${functionAppName}-id'
 var appServicePlanName = '${functionAppName}-plan'
 var applicationInsightsName = '${functionAppName}-appi'
@@ -240,6 +243,10 @@ resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
           name: 'HistoryProcessingCron'
           value: historyProcessingCron
         }
+        {
+          name: 'OpenDataPollIntervalCron'
+          value: openDataPollIntervalCron
+        }
       ]
       ftpsState: 'Disabled'
       http20Enabled: true
@@ -415,6 +422,42 @@ resource apimStationStatisticsCachePolicyFragment 'Microsoft.ApiManagement/servi
 
 
 // API operations — one per Function App HTTP endpoint.
+resource apimGetOpenData 'Microsoft.ApiManagement/service/apis/operations@2024-05-01' = {
+  name: 'get-open-data'
+  parent: apimApi
+  properties: {
+    displayName: 'Get open data'
+    method: 'GET'
+    urlTemplate: '/open-data'
+  }
+}
+
+resource apimOpenDataCachePolicy 'Microsoft.ApiManagement/service/apis/operations/policies@2024-05-01' = {
+  name: 'policy'
+  parent: apimGetOpenData
+  properties: {
+    format: 'xml'
+    value: '''
+<policies>
+  <inbound>
+    <base />
+    <cache-lookup vary-by-developer="false" vary-by-developer-groups="false" />
+  </inbound>
+  <backend>
+    <base />
+  </backend>
+  <outbound>
+    <base />
+    <cache-store duration="120" />
+  </outbound>
+  <on-error>
+    <base />
+  </on-error>
+</policies>
+'''
+  }
+}
+
 resource apimGetStations 'Microsoft.ApiManagement/service/apis/operations@2024-05-01' = {
   name: 'get-stations'
   parent: apimApi

--- a/src/HslBikeDataAggregator/Configuration/OpenDataOptions.cs
+++ b/src/HslBikeDataAggregator/Configuration/OpenDataOptions.cs
@@ -1,0 +1,18 @@
+namespace HslBikeDataAggregator.Configuration;
+
+public sealed class OpenDataOptions
+{
+    public int HistoryLimit { get; set; } = 60;
+    public List<VenueFillLevelConfig> VenueFillLevelSources { get; set; } = [];
+}
+
+public sealed class VenueFillLevelConfig
+{
+    public required string SourceId { get; set; }
+    public required string DisplayName { get; set; }
+    public required double Lat { get; set; }
+    public required double Lon { get; set; }
+    public required string AttributionUrl { get; set; }
+    public required string LocationId { get; set; }
+    public required string LocationUrlName { get; set; }
+}

--- a/src/HslBikeDataAggregator/Functions/GetOpenDataFunction.cs
+++ b/src/HslBikeDataAggregator/Functions/GetOpenDataFunction.cs
@@ -1,0 +1,36 @@
+using System.Net;
+
+using HslBikeDataAggregator.Models.OpenData;
+using HslBikeDataAggregator.Services.OpenData;
+using HslBikeDataAggregator.Storage;
+
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+
+namespace HslBikeDataAggregator.Functions;
+
+public sealed class GetOpenDataFunction(
+    IReadOnlyList<IOpenDataSource> sources,
+    IOpenDataBlobStorage openDataBlobStorage,
+    ILogger<GetOpenDataFunction> logger)
+{
+    private const string CacheControl = "public, max-age=120";
+
+    [Function(nameof(GetOpenData))]
+    public async Task<HttpResponseData> GetOpenData(
+        [HttpTrigger(AuthorizationLevel.Function, "get", Route = "open-data")] HttpRequestData request,
+        CancellationToken cancellationToken)
+    {
+        var timeSeries = await Task.WhenAll(
+            sources.Select(s => openDataBlobStorage.GetOpenDataTimeSeriesAsync(s.SourceId, cancellationToken)));
+
+        var result = timeSeries.OfType<OpenDataTimeSeries>().ToArray();
+
+        var response = request.CreateResponse(HttpStatusCode.OK);
+        response.Headers.Add("Cache-Control", CacheControl);
+        await response.WriteAsJsonAsync(result, cancellationToken);
+        logger.LogInformation("Served {Count} open data time series.", result.Length);
+        return response;
+    }
+}

--- a/src/HslBikeDataAggregator/Functions/PollOpenDataFunction.cs
+++ b/src/HslBikeDataAggregator/Functions/PollOpenDataFunction.cs
@@ -1,0 +1,22 @@
+using HslBikeDataAggregator.Services.OpenData;
+
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace HslBikeDataAggregator.Functions;
+
+public sealed class PollOpenDataFunction(OpenDataPollService openDataPollService, ILogger<PollOpenDataFunction> logger)
+{
+    [Function(nameof(PollOpenData))]
+    public async Task PollOpenData([TimerTrigger("%OpenDataPollIntervalCron%")] TimerInfo timerInfo, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("PollOpenData trigger fired at {Timestamp}. Next schedule: {NextSchedule}.", DateTimeOffset.UtcNow, timerInfo.ScheduleStatus?.Next);
+        var result = await openDataPollService.PollAsync(cancellationToken);
+
+        logger.LogInformation(
+            "PollOpenData completed at {Timestamp}. Polled {SourceCount} sources, {SuccessCount} succeeded.",
+            result.Timestamp,
+            result.SourceCount,
+            result.SuccessCount);
+    }
+}

--- a/src/HslBikeDataAggregator/Models/OpenData/OpenDataTimeSeries.cs
+++ b/src/HslBikeDataAggregator/Models/OpenData/OpenDataTimeSeries.cs
@@ -1,0 +1,40 @@
+using System.Text.Json.Serialization;
+
+namespace HslBikeDataAggregator.Models.OpenData;
+
+public sealed record OpenDataTimeSeries
+{
+    [JsonPropertyName("sourceId")]
+    public required string SourceId { get; init; }
+
+    [JsonPropertyName("displayName")]
+    public required string DisplayName { get; init; }
+
+    [JsonPropertyName("lat")]
+    public required double Lat { get; init; }
+
+    [JsonPropertyName("lon")]
+    public required double Lon { get; init; }
+
+    [JsonPropertyName("attributionUrl")]
+    public required string AttributionUrl { get; init; }
+
+    [JsonPropertyName("timestamps")]
+    public required IReadOnlyList<DateTimeOffset> Timestamps { get; init; }
+
+    [JsonPropertyName("values")]
+    public required IReadOnlyList<double> Values { get; init; }
+
+    public static OpenDataTimeSeries CreateEmpty(
+        string sourceId, string displayName, double lat, double lon, string attributionUrl) =>
+        new()
+        {
+            SourceId = sourceId,
+            DisplayName = displayName,
+            Lat = lat,
+            Lon = lon,
+            AttributionUrl = attributionUrl,
+            Timestamps = [],
+            Values = []
+        };
+}

--- a/src/HslBikeDataAggregator/Program.cs
+++ b/src/HslBikeDataAggregator/Program.cs
@@ -3,12 +3,14 @@ using Azure.Storage.Blobs;
 
 using HslBikeDataAggregator.Configuration;
 using HslBikeDataAggregator.Services;
+using HslBikeDataAggregator.Services.OpenData;
 using HslBikeDataAggregator.Storage;
 
 using Microsoft.Azure.Functions.Worker.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 
 var builder = FunctionsApplication.CreateBuilder(args);
 
@@ -35,9 +37,21 @@ builder.Services
             options.RollingWindowMonthCount);
     });
 
+builder.Services
+    .AddOptions<OpenDataOptions>()
+    .Configure<IConfiguration>((options, configuration) =>
+    {
+        options.HistoryLimit = configuration.GetValue<int?>("OpenData:HistoryLimit") ?? 60;
+        options.VenueFillLevelSources = configuration
+            .GetSection("OpenData:VenueFillLevelSources")
+            .Get<List<VenueFillLevelConfig>>() ?? [];
+    });
+
 builder.Services.AddHttpClient<DigitransitStationClient>()
     .AddStandardResilienceHandler();
 builder.Services.AddHttpClient<ProcessStationHistoryService>();
+builder.Services.AddHttpClient("VenueFillLevel")
+    .AddStandardResilienceHandler();
 builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddSingleton<LiveStationCacheService>();
 builder.Services.AddSingleton(provider =>
@@ -71,5 +85,15 @@ builder.Services.AddSingleton(provider =>
 builder.Services.AddSingleton<IBikeDataBlobStorage, BikeDataBlobStorage>();
 builder.Services.AddSingleton<IPollStationsService, PollStationsService>();
 builder.Services.AddSingleton<AggregatedBikeDataService>();
+builder.Services.AddSingleton<IReadOnlyList<IOpenDataSource>>(provider =>
+{
+    var opts = provider.GetRequiredService<IOptions<OpenDataOptions>>().Value;
+    var factory = provider.GetRequiredService<IHttpClientFactory>();
+    return opts.VenueFillLevelSources
+        .Select(config => (IOpenDataSource)new VenueFillLevelSource(config, factory.CreateClient("VenueFillLevel")))
+        .ToList();
+});
+builder.Services.AddSingleton<IOpenDataBlobStorage, OpenDataBlobStorage>();
+builder.Services.AddSingleton<OpenDataPollService>();
 
 builder.Build().Run();

--- a/src/HslBikeDataAggregator/Services/OpenData/IOpenDataSource.cs
+++ b/src/HslBikeDataAggregator/Services/OpenData/IOpenDataSource.cs
@@ -1,0 +1,13 @@
+namespace HslBikeDataAggregator.Services.OpenData;
+
+public interface IOpenDataSource
+{
+    string SourceId { get; }
+    string DisplayName { get; }
+    double Lat { get; }
+    double Lon { get; }
+    string AttributionUrl { get; }
+
+    /// Returns null when data is unavailable (e.g. out of season) — caller records -1 sentinel.
+    Task<double?> FetchAsync(CancellationToken cancellationToken);
+}

--- a/src/HslBikeDataAggregator/Services/OpenData/OpenDataPollService.cs
+++ b/src/HslBikeDataAggregator/Services/OpenData/OpenDataPollService.cs
@@ -1,0 +1,84 @@
+using HslBikeDataAggregator.Configuration;
+using HslBikeDataAggregator.Models.OpenData;
+using HslBikeDataAggregator.Storage;
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace HslBikeDataAggregator.Services.OpenData;
+
+public sealed class OpenDataPollService(
+    IReadOnlyList<IOpenDataSource> sources,
+    IOpenDataBlobStorage blobStorage,
+    IOptions<OpenDataOptions> options,
+    TimeProvider timeProvider,
+    ILogger<OpenDataPollService> logger)
+{
+    public async Task<PollOpenDataResult> PollAsync(CancellationToken cancellationToken)
+    {
+        var timestamp = timeProvider.GetUtcNow();
+        var historyLimit = Math.Max(1, options.Value.HistoryLimit);
+        var successCount = 0;
+
+        foreach (var source in sources)
+        {
+            double value;
+            try
+            {
+                var fetched = await source.FetchAsync(cancellationToken);
+                value = fetched ?? -1;
+                if (fetched.HasValue) successCount++;
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Source {SourceId} fetch failed; recording sentinel.", source.SourceId);
+                value = -1;
+            }
+
+            var existing = await blobStorage.GetOpenDataTimeSeriesAsync(source.SourceId, cancellationToken)
+                ?? OpenDataTimeSeries.CreateEmpty(source.SourceId, source.DisplayName, source.Lat, source.Lon, source.AttributionUrl);
+
+            var updated = AppendValue(existing, timestamp, value, historyLimit, source);
+            await blobStorage.WriteOpenDataTimeSeriesAsync(updated, cancellationToken);
+
+            logger.LogInformation(
+                "Stored open data sample for {SourceId}: value={Value}, retained {SnapshotCount} snapshots.",
+                source.SourceId,
+                value,
+                updated.Timestamps.Count);
+        }
+
+        return new PollOpenDataResult(timestamp, sources.Count, successCount);
+    }
+
+    private static OpenDataTimeSeries AppendValue(
+        OpenDataTimeSeries existing,
+        DateTimeOffset timestamp,
+        double value,
+        int historyLimit,
+        IOpenDataSource source)
+    {
+        var timestamps = existing.Timestamps
+            .Append(timestamp)
+            .OrderBy(static t => t)
+            .TakeLast(historyLimit)
+            .ToArray();
+
+        var values = existing.Values
+            .Append(value)
+            .TakeLast(historyLimit)
+            .ToArray();
+
+        return existing with
+        {
+            DisplayName = source.DisplayName,
+            Lat = source.Lat,
+            Lon = source.Lon,
+            AttributionUrl = source.AttributionUrl,
+            Timestamps = timestamps,
+            Values = values
+        };
+    }
+}
+
+public sealed record PollOpenDataResult(DateTimeOffset Timestamp, int SourceCount, int SuccessCount);

--- a/src/HslBikeDataAggregator/Services/OpenData/VenueFillLevelSource.cs
+++ b/src/HslBikeDataAggregator/Services/OpenData/VenueFillLevelSource.cs
@@ -1,6 +1,5 @@
 using System.Net.Http.Json;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 
 using HslBikeDataAggregator.Configuration;
 
@@ -31,12 +30,12 @@ public sealed class VenueFillLevelSource(VenueFillLevelConfig config, HttpClient
 
         var element = await response.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: cancellationToken);
 
-        // API may return an object or a single-element array
-        var obj = element.ValueKind == JsonValueKind.Array && element.GetArrayLength() > 0
-            ? element[0]
-            : element;
+        if (element.TryGetProperty("isError", out var isError) && isError.GetBoolean())
+            return null;
 
-        return obj.TryGetProperty("currentAmount", out var prop) && prop.TryGetInt32(out var amount)
+        return element.TryGetProperty("result", out var result)
+            && result.TryGetProperty("fill_level", out var fillLevel)
+            && fillLevel.TryGetInt32(out var amount)
             ? (double)amount
             : null;
     }

--- a/src/HslBikeDataAggregator/Services/OpenData/VenueFillLevelSource.cs
+++ b/src/HslBikeDataAggregator/Services/OpenData/VenueFillLevelSource.cs
@@ -1,0 +1,43 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using HslBikeDataAggregator.Configuration;
+
+namespace HslBikeDataAggregator.Services.OpenData;
+
+public sealed class VenueFillLevelSource(VenueFillLevelConfig config, HttpClient httpClient) : IOpenDataSource
+{
+    private static readonly Uri ApiUri = new("https://helsinki.jaskaretail.com/api/select/current_fill_level_ws");
+
+    public string SourceId => config.SourceId;
+    public string DisplayName => config.DisplayName;
+    public double Lat => config.Lat;
+    public double Lon => config.Lon;
+    public string AttributionUrl => config.AttributionUrl;
+
+    public async Task<double?> FetchAsync(CancellationToken cancellationToken)
+    {
+        var payload = new
+        {
+            location_id = config.LocationId,
+            location_url_name = config.LocationUrlName,
+            current_fill_level_type = "SINGLE",
+            module_type = "current_fill_level"
+        };
+
+        using var response = await httpClient.PostAsJsonAsync(ApiUri, payload, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        var element = await response.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: cancellationToken);
+
+        // API may return an object or a single-element array
+        var obj = element.ValueKind == JsonValueKind.Array && element.GetArrayLength() > 0
+            ? element[0]
+            : element;
+
+        return obj.TryGetProperty("currentAmount", out var prop) && prop.TryGetInt32(out var amount)
+            ? (double)amount
+            : null;
+    }
+}

--- a/src/HslBikeDataAggregator/Storage/BikeDataBlobNames.cs
+++ b/src/HslBikeDataAggregator/Storage/BikeDataBlobNames.cs
@@ -5,11 +5,14 @@ public static class BikeDataBlobNames
     public const string ContainerName = "bike-data";
     public const string RecentSnapshots = "snapshots/recent.json";
     public const string MonthlyStatisticsPrefix = "monthly-stats/";
+    public const string OpenDataPrefix = "open-data/";
 
     /// <summary>
     /// Returns the blob name for a station's monthly statistics profile.
     /// </summary>
     public static string MonthlyStatistics(string stationId) => $"{MonthlyStatisticsPrefix}{SanitiseStationId(stationId)}.json";
+
+    public static string OpenDataTimeSeries(string sourceId) => $"{OpenDataPrefix}{SanitiseStationId(sourceId)}/recent.json";
 
     /// <summary>
     /// Validates that a station ID does not contain path-traversal or control characters.

--- a/src/HslBikeDataAggregator/Storage/IOpenDataBlobStorage.cs
+++ b/src/HslBikeDataAggregator/Storage/IOpenDataBlobStorage.cs
@@ -1,0 +1,9 @@
+using HslBikeDataAggregator.Models.OpenData;
+
+namespace HslBikeDataAggregator.Storage;
+
+public interface IOpenDataBlobStorage
+{
+    Task<OpenDataTimeSeries?> GetOpenDataTimeSeriesAsync(string sourceId, CancellationToken cancellationToken);
+    Task WriteOpenDataTimeSeriesAsync(OpenDataTimeSeries timeSeries, CancellationToken cancellationToken);
+}

--- a/src/HslBikeDataAggregator/Storage/OpenDataBlobStorage.cs
+++ b/src/HslBikeDataAggregator/Storage/OpenDataBlobStorage.cs
@@ -1,0 +1,48 @@
+using System.Text.Json;
+
+using Azure.Storage.Blobs;
+
+using HslBikeDataAggregator.Models.OpenData;
+
+namespace HslBikeDataAggregator.Storage;
+
+public sealed class OpenDataBlobStorage(BlobContainerClient blobContainerClient) : IOpenDataBlobStorage
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web);
+
+    public async Task<OpenDataTimeSeries?> GetOpenDataTimeSeriesAsync(string sourceId, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sourceId);
+
+        var content = await DownloadBlobContentAsync(BikeDataBlobNames.OpenDataTimeSeries(sourceId), cancellationToken);
+        return content?.ToObjectFromJson<OpenDataTimeSeries>(SerializerOptions);
+    }
+
+    public async Task WriteOpenDataTimeSeriesAsync(OpenDataTimeSeries timeSeries, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(timeSeries);
+
+        await blobContainerClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
+        await blobContainerClient
+            .GetBlobClient(BikeDataBlobNames.OpenDataTimeSeries(timeSeries.SourceId))
+            .UploadAsync(BinaryData.FromObjectAsJson(timeSeries, SerializerOptions), overwrite: true, cancellationToken);
+    }
+
+    private async Task<BinaryData?> DownloadBlobContentAsync(string blobName, CancellationToken cancellationToken)
+    {
+        await blobContainerClient.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
+
+        try
+        {
+            var response = await blobContainerClient
+                .GetBlobClient(blobName)
+                .DownloadContentAsync(cancellationToken);
+
+            return response.Value.Content;
+        }
+        catch (Azure.RequestFailedException exception) when (exception.Status == 404)
+        {
+            return null;
+        }
+    }
+}

--- a/src/HslBikeDataAggregator/local.settings.example.json
+++ b/src/HslBikeDataAggregator/local.settings.example.json
@@ -5,6 +5,15 @@
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
     "DigitransitSubscriptionKey": "",
     "PollIntervalCron": "0 */15 * * * *",
-    "SnapshotHistoryLimit": "60"
+    "SnapshotHistoryLimit": "60",
+    "OpenDataPollIntervalCron": "0 */15 * * * *",
+    "OpenData:HistoryLimit": "60",
+    "OpenData:VenueFillLevelSources:0:SourceId": "uimastadion",
+    "OpenData:VenueFillLevelSources:0:DisplayName": "Uimastadion",
+    "OpenData:VenueFillLevelSources:0:Lat": "60.1857",
+    "OpenData:VenueFillLevelSources:0:Lon": "24.9282",
+    "OpenData:VenueFillLevelSources:0:AttributionUrl": "https://helsinki.jaskaretail.com/current-fill-level/info/uimastadion",
+    "OpenData:VenueFillLevelSources:0:LocationId": "180",
+    "OpenData:VenueFillLevelSources:0:LocationUrlName": "uimastadion"
   }
 }

--- a/tests/HslBikeDataAggregator.Tests/Functions/GetOpenDataFunctionTests.cs
+++ b/tests/HslBikeDataAggregator.Tests/Functions/GetOpenDataFunctionTests.cs
@@ -1,0 +1,110 @@
+using System.Net;
+using System.Security.Claims;
+
+using Azure.Core.Serialization;
+
+using HslBikeDataAggregator.Functions;
+using HslBikeDataAggregator.Models.OpenData;
+using HslBikeDataAggregator.Services.OpenData;
+using HslBikeDataAggregator.Storage;
+
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Moq;
+
+namespace HslBikeDataAggregator.Tests.Functions;
+
+public sealed class GetOpenDataFunctionTests
+{
+    [Fact]
+    public async Task GetOpenData_ReturnsOkWithCacheHeadersAndTimeSeries()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var request = CreateMockRequest("https://localhost/api/open-data");
+
+        var source = new Mock<IOpenDataSource>();
+        source.SetupGet(s => s.SourceId).Returns("uimastadion");
+
+        var timeSeries = new OpenDataTimeSeries
+        {
+            SourceId = "uimastadion",
+            DisplayName = "Uimastadion",
+            Lat = 60.1857,
+            Lon = 24.9282,
+            AttributionUrl = "https://example.com",
+            Timestamps = [new DateTimeOffset(2026, 5, 1, 10, 0, 0, TimeSpan.Zero)],
+            Values = [45.0]
+        };
+
+        var blobStorage = new Mock<IOpenDataBlobStorage>();
+        blobStorage.Setup(s => s.GetOpenDataTimeSeriesAsync("uimastadion", cancellationToken)).ReturnsAsync(timeSeries);
+
+        var function = new GetOpenDataFunction([source.Object], blobStorage.Object, NullLogger<GetOpenDataFunction>.Instance);
+
+        var response = await function.GetOpenData(request.Object, cancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.True(response.Headers.TryGetValues("Cache-Control", out var cacheControl));
+        Assert.Contains("public, max-age=120", cacheControl);
+
+        response.Body.Position = 0;
+        using var reader = new StreamReader(response.Body);
+        var body = await reader.ReadToEndAsync(cancellationToken);
+        Assert.Contains("\"sourceId\":\"uimastadion\"", body, StringComparison.Ordinal);
+        Assert.Contains("\"displayName\":\"Uimastadion\"", body, StringComparison.Ordinal);
+        Assert.Contains("45", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetOpenData_FiltersNullTimeSeries_WhenBlobNotYetPopulated()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var request = CreateMockRequest("https://localhost/api/open-data");
+
+        var source = new Mock<IOpenDataSource>();
+        source.SetupGet(s => s.SourceId).Returns("uimastadion");
+
+        var blobStorage = new Mock<IOpenDataBlobStorage>();
+        blobStorage.Setup(s => s.GetOpenDataTimeSeriesAsync("uimastadion", cancellationToken)).ReturnsAsync((OpenDataTimeSeries?)null);
+
+        var function = new GetOpenDataFunction([source.Object], blobStorage.Object, NullLogger<GetOpenDataFunction>.Instance);
+
+        var response = await function.GetOpenData(request.Object, cancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        response.Body.Position = 0;
+        using var reader = new StreamReader(response.Body);
+        Assert.Equal("[]", await reader.ReadToEndAsync(cancellationToken));
+    }
+
+    private static Mock<HttpRequestData> CreateMockRequest(string url)
+    {
+        var services = new ServiceCollection();
+        services
+            .AddOptions<WorkerOptions>()
+            .Configure(options => options.Serializer = new JsonObjectSerializer());
+
+        var serviceProvider = services.BuildServiceProvider();
+        var functionContext = new Mock<FunctionContext>();
+        functionContext.SetupProperty(c => c.InstanceServices, serviceProvider);
+
+        var responseBody = new MemoryStream();
+        var response = new Mock<HttpResponseData>(functionContext.Object);
+        response.SetupProperty(r => r.StatusCode);
+        response.SetupProperty(r => r.Body, responseBody);
+        response.SetupGet(r => r.Headers).Returns(new HttpHeadersCollection());
+        response.SetupGet(r => r.Cookies).Returns(Mock.Of<HttpCookies>());
+
+        var request = new Mock<HttpRequestData>(functionContext.Object);
+        request.Setup(r => r.CreateResponse()).Returns(response.Object);
+        request.SetupGet(r => r.Body).Returns(Stream.Null);
+        request.SetupGet(r => r.Headers).Returns(new HttpHeadersCollection());
+        request.SetupGet(r => r.Identities).Returns(Array.Empty<ClaimsIdentity>());
+        request.SetupGet(r => r.Method).Returns("GET");
+        request.SetupGet(r => r.Url).Returns(new Uri(url));
+        return request;
+    }
+}

--- a/tests/HslBikeDataAggregator.Tests/Functions/PollOpenDataFunctionTests.cs
+++ b/tests/HslBikeDataAggregator.Tests/Functions/PollOpenDataFunctionTests.cs
@@ -1,0 +1,24 @@
+using System.Reflection;
+
+using HslBikeDataAggregator.Functions;
+
+using Microsoft.Azure.Functions.Worker;
+
+namespace HslBikeDataAggregator.Tests.Functions;
+
+public sealed class PollOpenDataFunctionTests
+{
+    [Fact]
+    public void PollOpenData_UsesConfiguredCronExpression()
+    {
+        var method = typeof(PollOpenDataFunction).GetMethod(nameof(PollOpenDataFunction.PollOpenData), BindingFlags.Instance | BindingFlags.Public);
+
+        Assert.NotNull(method);
+
+        var timerParameter = method!.GetParameters()[0];
+        var timerTriggerAttribute = timerParameter.GetCustomAttribute<TimerTriggerAttribute>();
+
+        Assert.NotNull(timerTriggerAttribute);
+        Assert.Equal("%OpenDataPollIntervalCron%", timerTriggerAttribute!.Schedule);
+    }
+}

--- a/tests/HslBikeDataAggregator.Tests/Services/OpenDataPollServiceTests.cs
+++ b/tests/HslBikeDataAggregator.Tests/Services/OpenDataPollServiceTests.cs
@@ -1,0 +1,221 @@
+using HslBikeDataAggregator.Configuration;
+using HslBikeDataAggregator.Models.OpenData;
+using HslBikeDataAggregator.Services.OpenData;
+using HslBikeDataAggregator.Storage;
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+using Moq;
+
+namespace HslBikeDataAggregator.Tests.Services;
+
+public sealed class OpenDataPollServiceTests
+{
+    [Fact]
+    public async Task PollAsync_AppendsValueAndTrimsHistory()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var timestamp = new DateTimeOffset(2026, 5, 1, 10, 15, 0, TimeSpan.Zero);
+
+        var source = CreateSource("uimastadion");
+        source.Setup(s => s.FetchAsync(cancellationToken)).ReturnsAsync(45.0);
+
+        var existing = new OpenDataTimeSeries
+        {
+            SourceId = "uimastadion",
+            DisplayName = "Uimastadion",
+            Lat = 60.1857,
+            Lon = 24.9282,
+            AttributionUrl = "https://example.com",
+            Timestamps =
+            [
+                new DateTimeOffset(2026, 5, 1, 10, 0, 0, TimeSpan.Zero),
+                new DateTimeOffset(2026, 5, 1, 10, 5, 0, TimeSpan.Zero)
+            ],
+            Values = [30.0, 35.0]
+        };
+
+        var blobStorage = new Mock<IOpenDataBlobStorage>();
+        blobStorage.Setup(s => s.GetOpenDataTimeSeriesAsync("uimastadion", cancellationToken)).ReturnsAsync(existing);
+
+        OpenDataTimeSeries? written = null;
+        blobStorage
+            .Setup(s => s.WriteOpenDataTimeSeriesAsync(It.IsAny<OpenDataTimeSeries>(), cancellationToken))
+            .Callback<OpenDataTimeSeries, CancellationToken>((ts, _) => written = ts)
+            .Returns(Task.CompletedTask);
+
+        var service = CreateService([source.Object], blobStorage.Object, historyLimit: 2, timestamp);
+
+        var result = await service.PollAsync(cancellationToken);
+
+        Assert.NotNull(written);
+        Assert.Equal(2, written!.Timestamps.Count);
+        Assert.Equal(2, written.Values.Count);
+        Assert.Equal(timestamp, written.Timestamps[^1]);
+        Assert.Equal(35.0, written.Values[0]);
+        Assert.Equal(45.0, written.Values[^1]);
+
+        Assert.Equal(timestamp, result.Timestamp);
+        Assert.Equal(1, result.SourceCount);
+        Assert.Equal(1, result.SuccessCount);
+    }
+
+    [Fact]
+    public async Task PollAsync_RecordsSentinel_WhenFetchThrows()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var timestamp = new DateTimeOffset(2026, 5, 1, 10, 15, 0, TimeSpan.Zero);
+
+        var source = CreateSource("uimastadion");
+        source.Setup(s => s.FetchAsync(cancellationToken)).ThrowsAsync(new HttpRequestException("timeout"));
+
+        var blobStorage = CreateEmptyBlobStorage();
+
+        OpenDataTimeSeries? written = null;
+        blobStorage
+            .Setup(s => s.WriteOpenDataTimeSeriesAsync(It.IsAny<OpenDataTimeSeries>(), cancellationToken))
+            .Callback<OpenDataTimeSeries, CancellationToken>((ts, _) => written = ts)
+            .Returns(Task.CompletedTask);
+
+        var service = CreateService([source.Object], blobStorage.Object, historyLimit: 60, timestamp);
+
+        var result = await service.PollAsync(cancellationToken);
+
+        Assert.NotNull(written);
+        Assert.Equal(-1.0, Assert.Single(written!.Values));
+        Assert.Equal(1, result.SourceCount);
+        Assert.Equal(0, result.SuccessCount);
+    }
+
+    [Fact]
+    public async Task PollAsync_RecordsSentinel_WhenSourceReturnsNull()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var timestamp = new DateTimeOffset(2026, 5, 1, 10, 15, 0, TimeSpan.Zero);
+
+        var source = CreateSource("uimastadion");
+        source.Setup(s => s.FetchAsync(cancellationToken)).ReturnsAsync((double?)null);
+
+        var blobStorage = CreateEmptyBlobStorage();
+
+        OpenDataTimeSeries? written = null;
+        blobStorage
+            .Setup(s => s.WriteOpenDataTimeSeriesAsync(It.IsAny<OpenDataTimeSeries>(), cancellationToken))
+            .Callback<OpenDataTimeSeries, CancellationToken>((ts, _) => written = ts)
+            .Returns(Task.CompletedTask);
+
+        var service = CreateService([source.Object], blobStorage.Object, historyLimit: 60, timestamp);
+
+        var result = await service.PollAsync(cancellationToken);
+
+        Assert.NotNull(written);
+        Assert.Equal(-1.0, Assert.Single(written!.Values));
+        Assert.Equal(1, result.SourceCount);
+        Assert.Equal(0, result.SuccessCount);
+    }
+
+    [Fact]
+    public async Task PollAsync_OneSourceFailureDoesNotAffectOtherSources()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var timestamp = new DateTimeOffset(2026, 5, 1, 10, 15, 0, TimeSpan.Zero);
+
+        var source1 = CreateSource("source-a");
+        source1.Setup(s => s.FetchAsync(cancellationToken)).ThrowsAsync(new HttpRequestException("error"));
+
+        var source2 = CreateSource("source-b");
+        source2.Setup(s => s.FetchAsync(cancellationToken)).ReturnsAsync(100.0);
+
+        var writtenBySource = new Dictionary<string, OpenDataTimeSeries>();
+        var blobStorage = new Mock<IOpenDataBlobStorage>();
+        blobStorage
+            .Setup(s => s.GetOpenDataTimeSeriesAsync(It.IsAny<string>(), cancellationToken))
+            .ReturnsAsync((OpenDataTimeSeries?)null);
+        blobStorage
+            .Setup(s => s.WriteOpenDataTimeSeriesAsync(It.IsAny<OpenDataTimeSeries>(), cancellationToken))
+            .Callback<OpenDataTimeSeries, CancellationToken>((ts, _) => writtenBySource[ts.SourceId] = ts)
+            .Returns(Task.CompletedTask);
+
+        var service = CreateService([source1.Object, source2.Object], blobStorage.Object, historyLimit: 60, timestamp);
+
+        var result = await service.PollAsync(cancellationToken);
+
+        Assert.Equal(2, writtenBySource.Count);
+        Assert.Equal(-1.0, Assert.Single(writtenBySource["source-a"].Values));
+        Assert.Equal(100.0, Assert.Single(writtenBySource["source-b"].Values));
+        Assert.Equal(2, result.SourceCount);
+        Assert.Equal(1, result.SuccessCount);
+    }
+
+    [Fact]
+    public async Task PollAsync_RefreshesMetadata_WhenWritingTimeSeries()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var timestamp = new DateTimeOffset(2026, 5, 1, 10, 15, 0, TimeSpan.Zero);
+
+        var source = new Mock<IOpenDataSource>();
+        source.SetupGet(s => s.SourceId).Returns("uimastadion");
+        source.SetupGet(s => s.DisplayName).Returns("Uimastadion Updated");
+        source.SetupGet(s => s.Lat).Returns(60.19);
+        source.SetupGet(s => s.Lon).Returns(24.93);
+        source.SetupGet(s => s.AttributionUrl).Returns("https://new-attribution.com");
+        source.Setup(s => s.FetchAsync(cancellationToken)).ReturnsAsync(50.0);
+
+        var existing = OpenDataTimeSeries.CreateEmpty("uimastadion", "Old Name", 60.0, 25.0, "https://old.com");
+
+        var blobStorage = new Mock<IOpenDataBlobStorage>();
+        blobStorage.Setup(s => s.GetOpenDataTimeSeriesAsync("uimastadion", cancellationToken)).ReturnsAsync(existing);
+
+        OpenDataTimeSeries? written = null;
+        blobStorage
+            .Setup(s => s.WriteOpenDataTimeSeriesAsync(It.IsAny<OpenDataTimeSeries>(), cancellationToken))
+            .Callback<OpenDataTimeSeries, CancellationToken>((ts, _) => written = ts)
+            .Returns(Task.CompletedTask);
+
+        var service = CreateService([source.Object], blobStorage.Object, historyLimit: 60, timestamp);
+        await service.PollAsync(cancellationToken);
+
+        Assert.NotNull(written);
+        Assert.Equal("Uimastadion Updated", written!.DisplayName);
+        Assert.Equal(60.19, written.Lat);
+        Assert.Equal(24.93, written.Lon);
+        Assert.Equal("https://new-attribution.com", written.AttributionUrl);
+    }
+
+    private static Mock<IOpenDataSource> CreateSource(string sourceId)
+    {
+        var source = new Mock<IOpenDataSource>();
+        source.SetupGet(s => s.SourceId).Returns(sourceId);
+        source.SetupGet(s => s.DisplayName).Returns("Display " + sourceId);
+        source.SetupGet(s => s.Lat).Returns(60.0);
+        source.SetupGet(s => s.Lon).Returns(25.0);
+        source.SetupGet(s => s.AttributionUrl).Returns("https://example.com/" + sourceId);
+        return source;
+    }
+
+    private static Mock<IOpenDataBlobStorage> CreateEmptyBlobStorage()
+    {
+        var blobStorage = new Mock<IOpenDataBlobStorage>();
+        blobStorage
+            .Setup(s => s.GetOpenDataTimeSeriesAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((OpenDataTimeSeries?)null);
+        return blobStorage;
+    }
+
+    private static OpenDataPollService CreateService(
+        IReadOnlyList<IOpenDataSource> sources,
+        IOpenDataBlobStorage blobStorage,
+        int historyLimit,
+        DateTimeOffset timestamp) =>
+        new(sources,
+            blobStorage,
+            Options.Create(new OpenDataOptions { HistoryLimit = historyLimit }),
+            new FixedTimeProvider(timestamp),
+            NullLogger<OpenDataPollService>.Instance);
+
+    private sealed class FixedTimeProvider(DateTimeOffset timestamp) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => timestamp;
+    }
+}

--- a/tests/HslBikeDataAggregator.Tests/Services/VenueFillLevelSourceTests.cs
+++ b/tests/HslBikeDataAggregator.Tests/Services/VenueFillLevelSourceTests.cs
@@ -1,0 +1,91 @@
+using System.Net;
+using System.Text;
+
+using HslBikeDataAggregator.Configuration;
+using HslBikeDataAggregator.Services.OpenData;
+
+namespace HslBikeDataAggregator.Tests.Services;
+
+public sealed class VenueFillLevelSourceTests
+{
+    [Fact]
+    public async Task FetchAsync_ReturnsFillLevel_WhenResponseContainsResultObject()
+    {
+        var source = CreateSource("""
+            {
+              "result": {
+                "location_name": "Uimastadion",
+                "fill_level": 185,
+                "location_id": 180,
+                "capacity": 4000
+              },
+              "isError": false,
+              "message": "Operation successful"
+            }
+            """);
+
+        var value = await source.FetchAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(185.0, value);
+    }
+
+    [Fact]
+    public async Task FetchAsync_ReturnsNull_WhenIsErrorTrue()
+    {
+        var source = CreateSource("""
+            {
+              "result": null,
+              "isError": true,
+              "message": "Some error"
+            }
+            """);
+
+        var value = await source.FetchAsync(TestContext.Current.CancellationToken);
+
+        Assert.Null(value);
+    }
+
+    [Fact]
+    public async Task FetchAsync_ReturnsNull_WhenFillLevelFieldAbsent()
+    {
+        var source = CreateSource("""
+            {
+              "result": {
+                "location_name": "Uimastadion"
+              },
+              "isError": false
+            }
+            """);
+
+        var value = await source.FetchAsync(TestContext.Current.CancellationToken);
+
+        Assert.Null(value);
+    }
+
+    private static VenueFillLevelSource CreateSource(string responseBody)
+    {
+        var handler = new StubHttpMessageHandler(_ => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(responseBody, Encoding.UTF8, "application/json")
+        }));
+
+        var config = new VenueFillLevelConfig
+        {
+            SourceId = "uimastadion",
+            DisplayName = "Uimastadion",
+            Lat = 60.1857,
+            Lon = 24.9282,
+            AttributionUrl = "https://example.com",
+            LocationId = "180",
+            LocationUrlName = "uimastadion"
+        };
+
+        return new VenueFillLevelSource(config, new HttpClient(handler));
+    }
+
+    private sealed class StubHttpMessageHandler(Func<HttpRequestMessage, Task<HttpResponseMessage>> handler) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => handler(request);
+    }
+}


### PR DESCRIPTION
## Summary

- Introduces `IOpenDataSource` interface and `VenueFillLevelSource` as the first implementation (Uimastadion swimmer count via reverse-engineered jaskaretail API)
- `PollOpenDataFunction` timer-triggered function fans out over all configured sources; per-source failures record a `-1` sentinel without blocking other sources
- `GetOpenDataFunction` exposes `GET /api/open-data` returning a rolling time series per source, with 120 s cache-control
- `OpenDataBlobStorage` stores each source under `open-data/{sourceId}/recent.json` using the existing blob container
- Bicep wired up with new `openDataPollIntervalCron` parameter and APIM operation (120 s cache)
- Deploy workflows configure all seven Uimastadion source settings via `az functionapp config appsettings set`

## Test plan

- [x] `OpenDataPollServiceTests` — append + trim, sentinel on exception, sentinel on null return, one-source failure isolation, metadata refresh on write
- [x] `PollOpenDataFunctionTests` — timer trigger uses `%OpenDataPollIntervalCron%`
- [x] `GetOpenDataFunctionTests` — OK + cache header + JSON body, null blobs filtered to empty array
- [x] `dotnet build` — clean (0 warnings, 0 errors)
- [x] `dotnet test` — 87/87 passed

## Notes

- `OPEN_DATA_POLL_INTERVAL_CRON` must be added as a secret to both `dev` and `prod` GitHub environments; the `|| '0 */15 * * * *'` fallback in the workflow means it is optional
- `currentAmount` field name in the jaskaretail response should be verified once the function runs in dev — see `VenueFillLevelSource.cs`

Closes #67