### PR TITLE
Add unit and description to OpenDataTimeSeries (#72)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -65,7 +65,7 @@ All endpoints return JSON. Requests route through the APIM gateway which handles
 - `BikeStation` — id, name, lat/lon, capacity, bikesAvailable, spacesAvailable, isActive
 - `SnapshotTimeSeries` — intervalMinutes, timestamps[], rows[] (columnar: stationId + int counts)
 - `MonthlyStationStatistics` — month, demand profile, destination table
-- `OpenDataTimeSeries` — sourceId, displayName, lat, lon, attributionUrl, timestamps[], values[] (double; `-1` = unavailable)
+- `OpenDataTimeSeries` — sourceId, displayName, lat, lon, attributionUrl, optional unit, optional description, timestamps[], values[] (double; `-1` = unavailable)
 - `IOpenDataSource` — interface for pluggable open data source implementations; `FetchAsync` returns `double?` (`null` = out of season/unavailable)
 
 ## Conventions

--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ The time series uses a columnar layout to minimise payload size. Each station ro
 
 Each element in the array is a rolling time series for one configured source. A value of `-1` indicates the source was unavailable (e.g. out of season or a transient fetch failure).
 
+`unit` and `description` are optional and let the frontend render the value generically across heterogeneous source types (visitor counts, temperatures, percentages, etc.) without per-source code. Both are refreshed from configuration on every successful poll.
+
 ```json
 [
   {
@@ -166,6 +168,8 @@ Each element in the array is a rolling time series for one configured source. A 
     "lat": 60.1857,
     "lon": 24.9282,
     "attributionUrl": "https://helsinki.jaskaretail.com/current-fill-level/info/uimastadion",
+    "unit": "visitors",
+    "description": "Live visitor count at Uimastadion outdoor swimming pool",
     "timestamps": ["2026-05-18T10:00:00Z", "2026-05-18T10:15:00Z"],
     "values": [185, 192]
   }
@@ -244,7 +248,7 @@ Expected values:
 | `OpenDataPollIntervalCron` | NCRONTAB expression for `PollOpenData` | `0 */15 * * * *` |
 | `OpenData:HistoryLimit` | Maximum number of values retained per open data source | `60` |
 | `OpenData:VenueFillLevelSources:0:SourceId` | Source ID for the first venue fill level source | `uimastadion` |
-| `OpenData:VenueFillLevelSources:0:*` | Additional fields per source: `DisplayName`, `Lat`, `Lon`, `AttributionUrl`, `LocationId`, `LocationUrlName` | — |
+| `OpenData:VenueFillLevelSources:0:*` | Additional fields per source: `DisplayName`, `Lat`, `Lon`, `AttributionUrl`, `LocationId`, `LocationUrlName`, optional `Unit`, optional `Description` | — |
 
 In Azure, the storage connection uses managed identity (`AzureWebJobsStorage__accountName` + `AzureWebJobsStorage__clientId`) rather than a connection string.
 

--- a/docs/adr/004-open-data-polling-framework.md
+++ b/docs/adr/004-open-data-polling-framework.md
@@ -33,9 +33,9 @@ A single `PollOpenDataFunction` fans out over `IReadOnlyList<IOpenDataSource>`. 
 
 ### 3. Metadata embedded in each blob write
 
-`OpenDataTimeSeries` carries `displayName`, `lat`, `lon`, and `attributionUrl` alongside the time series data. These fields are refreshed from the source configuration on every poll write.
+`OpenDataTimeSeries` carries `displayName`, `lat`, `lon`, `attributionUrl`, and optional `unit` / `description` alongside the time series data. These fields are refreshed from the source configuration on every poll write.
 
-**Rationale:** `GetOpenDataFunction` reads blobs in parallel without needing access to the source configuration at read time, keeping the HTTP path simple. Config updates (e.g. a renamed display name) propagate automatically on the next successful poll.
+**Rationale:** `GetOpenDataFunction` reads blobs in parallel without needing access to the source configuration at read time, keeping the HTTP path simple. Config updates (e.g. a renamed display name, a new unit label) propagate automatically on the next successful poll. The optional `unit` and `description` let the frontend render heterogeneous source types (visitor counts, temperatures, percentages) through a single generic UI without per-source code.
 
 ### 4. `IReadOnlyList<IOpenDataSource>` registered via a factory singleton
 

--- a/src/HslBikeDataAggregator/Configuration/OpenDataOptions.cs
+++ b/src/HslBikeDataAggregator/Configuration/OpenDataOptions.cs
@@ -15,4 +15,6 @@ public sealed class VenueFillLevelConfig
     public required string AttributionUrl { get; set; }
     public required string LocationId { get; set; }
     public required string LocationUrlName { get; set; }
+    public string? Unit { get; set; }
+    public string? Description { get; set; }
 }

--- a/src/HslBikeDataAggregator/Models/OpenData/OpenDataTimeSeries.cs
+++ b/src/HslBikeDataAggregator/Models/OpenData/OpenDataTimeSeries.cs
@@ -19,6 +19,12 @@ public sealed record OpenDataTimeSeries
     [JsonPropertyName("attributionUrl")]
     public required string AttributionUrl { get; init; }
 
+    [JsonPropertyName("unit")]
+    public string? Unit { get; init; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
     [JsonPropertyName("timestamps")]
     public required IReadOnlyList<DateTimeOffset> Timestamps { get; init; }
 
@@ -26,7 +32,13 @@ public sealed record OpenDataTimeSeries
     public required IReadOnlyList<double> Values { get; init; }
 
     public static OpenDataTimeSeries CreateEmpty(
-        string sourceId, string displayName, double lat, double lon, string attributionUrl) =>
+        string sourceId,
+        string displayName,
+        double lat,
+        double lon,
+        string attributionUrl,
+        string? unit = null,
+        string? description = null) =>
         new()
         {
             SourceId = sourceId,
@@ -34,6 +46,8 @@ public sealed record OpenDataTimeSeries
             Lat = lat,
             Lon = lon,
             AttributionUrl = attributionUrl,
+            Unit = unit,
+            Description = description,
             Timestamps = [],
             Values = []
         };

--- a/src/HslBikeDataAggregator/Services/OpenData/IOpenDataSource.cs
+++ b/src/HslBikeDataAggregator/Services/OpenData/IOpenDataSource.cs
@@ -7,6 +7,8 @@ public interface IOpenDataSource
     double Lat { get; }
     double Lon { get; }
     string AttributionUrl { get; }
+    string? Unit { get; }
+    string? Description { get; }
 
     /// Returns null when data is unavailable (e.g. out of season) — caller records -1 sentinel.
     Task<double?> FetchAsync(CancellationToken cancellationToken);

--- a/src/HslBikeDataAggregator/Services/OpenData/OpenDataPollService.cs
+++ b/src/HslBikeDataAggregator/Services/OpenData/OpenDataPollService.cs
@@ -36,7 +36,14 @@ public sealed class OpenDataPollService(
             }
 
             var existing = await blobStorage.GetOpenDataTimeSeriesAsync(source.SourceId, cancellationToken)
-                ?? OpenDataTimeSeries.CreateEmpty(source.SourceId, source.DisplayName, source.Lat, source.Lon, source.AttributionUrl);
+                ?? OpenDataTimeSeries.CreateEmpty(
+                    source.SourceId,
+                    source.DisplayName,
+                    source.Lat,
+                    source.Lon,
+                    source.AttributionUrl,
+                    source.Unit,
+                    source.Description);
 
             var updated = AppendValue(existing, timestamp, value, historyLimit, source);
             await blobStorage.WriteOpenDataTimeSeriesAsync(updated, cancellationToken);
@@ -75,6 +82,8 @@ public sealed class OpenDataPollService(
             Lat = source.Lat,
             Lon = source.Lon,
             AttributionUrl = source.AttributionUrl,
+            Unit = source.Unit,
+            Description = source.Description,
             Timestamps = timestamps,
             Values = values
         };

--- a/src/HslBikeDataAggregator/Services/OpenData/VenueFillLevelSource.cs
+++ b/src/HslBikeDataAggregator/Services/OpenData/VenueFillLevelSource.cs
@@ -14,6 +14,8 @@ public sealed class VenueFillLevelSource(VenueFillLevelConfig config, HttpClient
     public double Lat => config.Lat;
     public double Lon => config.Lon;
     public string AttributionUrl => config.AttributionUrl;
+    public string? Unit => config.Unit;
+    public string? Description => config.Description;
 
     public async Task<double?> FetchAsync(CancellationToken cancellationToken)
     {

--- a/src/HslBikeDataAggregator/local.settings.example.json
+++ b/src/HslBikeDataAggregator/local.settings.example.json
@@ -14,6 +14,8 @@
     "OpenData:VenueFillLevelSources:0:Lon": "24.9282",
     "OpenData:VenueFillLevelSources:0:AttributionUrl": "https://helsinki.jaskaretail.com/current-fill-level/info/uimastadion",
     "OpenData:VenueFillLevelSources:0:LocationId": "180",
-    "OpenData:VenueFillLevelSources:0:LocationUrlName": "uimastadion"
+    "OpenData:VenueFillLevelSources:0:LocationUrlName": "uimastadion",
+    "OpenData:VenueFillLevelSources:0:Unit": "visitors",
+    "OpenData:VenueFillLevelSources:0:Description": "Live visitor count at Uimastadion outdoor swimming pool"
   }
 }

--- a/tests/HslBikeDataAggregator.Tests/Functions/GetOpenDataFunctionTests.cs
+++ b/tests/HslBikeDataAggregator.Tests/Functions/GetOpenDataFunctionTests.cs
@@ -35,6 +35,8 @@ public sealed class GetOpenDataFunctionTests
             Lat = 60.1857,
             Lon = 24.9282,
             AttributionUrl = "https://example.com",
+            Unit = "visitors",
+            Description = "Live visitor count",
             Timestamps = [new DateTimeOffset(2026, 5, 1, 10, 0, 0, TimeSpan.Zero)],
             Values = [45.0]
         };
@@ -55,6 +57,8 @@ public sealed class GetOpenDataFunctionTests
         var body = await reader.ReadToEndAsync(cancellationToken);
         Assert.Contains("\"sourceId\":\"uimastadion\"", body, StringComparison.Ordinal);
         Assert.Contains("\"displayName\":\"Uimastadion\"", body, StringComparison.Ordinal);
+        Assert.Contains("\"unit\":\"visitors\"", body, StringComparison.Ordinal);
+        Assert.Contains("\"description\":\"Live visitor count\"", body, StringComparison.Ordinal);
         Assert.Contains("45", body, StringComparison.Ordinal);
     }
 

--- a/tests/HslBikeDataAggregator.Tests/Services/OpenDataPollServiceTests.cs
+++ b/tests/HslBikeDataAggregator.Tests/Services/OpenDataPollServiceTests.cs
@@ -160,6 +160,8 @@ public sealed class OpenDataPollServiceTests
         source.SetupGet(s => s.Lat).Returns(60.19);
         source.SetupGet(s => s.Lon).Returns(24.93);
         source.SetupGet(s => s.AttributionUrl).Returns("https://new-attribution.com");
+        source.SetupGet(s => s.Unit).Returns("visitors");
+        source.SetupGet(s => s.Description).Returns("Live visitor count");
         source.Setup(s => s.FetchAsync(cancellationToken)).ReturnsAsync(50.0);
 
         var existing = OpenDataTimeSeries.CreateEmpty("uimastadion", "Old Name", 60.0, 25.0, "https://old.com");
@@ -181,6 +183,33 @@ public sealed class OpenDataPollServiceTests
         Assert.Equal(60.19, written.Lat);
         Assert.Equal(24.93, written.Lon);
         Assert.Equal("https://new-attribution.com", written.AttributionUrl);
+        Assert.Equal("visitors", written.Unit);
+        Assert.Equal("Live visitor count", written.Description);
+    }
+
+    [Fact]
+    public async Task PollAsync_LeavesUnitAndDescriptionNull_WhenSourceDoesNotProvideThem()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var timestamp = new DateTimeOffset(2026, 5, 1, 10, 15, 0, TimeSpan.Zero);
+
+        var source = CreateSource("legacy-source");
+        source.Setup(s => s.FetchAsync(cancellationToken)).ReturnsAsync(10.0);
+
+        var blobStorage = CreateEmptyBlobStorage();
+
+        OpenDataTimeSeries? written = null;
+        blobStorage
+            .Setup(s => s.WriteOpenDataTimeSeriesAsync(It.IsAny<OpenDataTimeSeries>(), cancellationToken))
+            .Callback<OpenDataTimeSeries, CancellationToken>((ts, _) => written = ts)
+            .Returns(Task.CompletedTask);
+
+        var service = CreateService([source.Object], blobStorage.Object, historyLimit: 60, timestamp);
+        await service.PollAsync(cancellationToken);
+
+        Assert.NotNull(written);
+        Assert.Null(written!.Unit);
+        Assert.Null(written.Description);
     }
 
     private static Mock<IOpenDataSource> CreateSource(string sourceId)


### PR DESCRIPTION
Closes #72.

## Summary
- Add optional `unit` and `description` to `OpenDataTimeSeries`, `IOpenDataSource`, and `VenueFillLevelConfig`.
- `OpenDataPollService` refreshes both fields on every poll, matching ADR 004's existing config-refresh-on-write pattern.
- Configure uimastadion with `unit: "visitors"` and a one-line description in `local.settings.example.json`.
- Update README, ADR 004, and copilot-instructions to document the new fields.
- Existing sources without configured values serialise as `null`, so this is a non-breaking change for clients that ignore them.

## Why
The [HslBikeApp frontend (#25)](https://github.com/TmiKuoste/HslBikeApp/issues/25) is adding a map layer + details panel for open data sources. The panel needs to render generically across many source types (visitor counts, temperatures, percentages) without hardcoding a per-`sourceId` lookup in the frontend.

## Test plan
- [x] `dotnet build HslBikeDataAggregator.slnx`
- [x] `dotnet test HslBikeDataAggregator.slnx` — 91 passed
- [x] New test: `PollAsync_LeavesUnitAndDescriptionNull_WhenSourceDoesNotProvideThem`
- [x] Updated test: `PollAsync_RefreshesMetadata_WhenWritingTimeSeries` now exercises unit + description
- [x] Updated test: `GetOpenData_ReturnsOkWithCacheHeadersAndTimeSeries` asserts unit/description in serialised body